### PR TITLE
making string validation compatible with python 2.7 and 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev
+# command to install dependencies
+install: "pip install -r requirements.txt"
+# command to run tests
+script: py.test tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ python:
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to run tests
-script: py.test tests
+script: py.test tests --ignore=tests/test_e2e_examples.py

--- a/adal/argument.py
+++ b/adal/argument.py
@@ -25,13 +25,15 @@
 #
 #------------------------------------------------------------------------------
 
+import six
+
 def validate_string_param(value, name):
 
     if not value:
         raise ValueError("The {0} parameter is required".format(name))
 
-    if not isinstance(value, str):
-        raise TypeError("The {0} parameter must be of type str".format(name))
+    if not isinstance(value, six.string_types):
+        raise TypeError("The {0} parameter must be a string".format(name))
 
 def validate_callback_type(callback):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 httpretty
+pytest
 requests
 python-dateutil
 PyJWT

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,6 @@ setup(
     install_requires=[
         'PyJWT',
         'requests',
-        'six'
+        'six',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,6 @@ setup(
     install_requires=[
         'PyJWT',
         'requests',
+        'six'
     ]
 )

--- a/tests/test_e2e_examples.py
+++ b/tests/test_e2e_examples.py
@@ -28,6 +28,9 @@
 import unittest
 import base64
 import json
+
+import pytest
+
 import adal
 
 try:
@@ -36,6 +39,8 @@ try:
 except:
     raise Exception("Author a config.py with values for the tests. See config_sample.py for details.")
 
+
+@pytest.mark.skip(reason="needs some way to get configuration settings from environment")
 class TestE2EExamples(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_e2e_examples.py
+++ b/tests/test_e2e_examples.py
@@ -40,7 +40,6 @@ except:
     raise Exception("Author a config.py with values for the tests. See config_sample.py for details.")
 
 
-@pytest.mark.skip(reason="needs some way to get configuration settings from environment")
 class TestE2EExamples(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
We're still using python 2.7, which has both `str` and `unicode` classes for strings.

This change makes the code run on 2.7 (as well as 3) if the string to be validated is a `unicode` type.

