### PR TITLE
Set version range on dependency packages

### DIFF
--- a/adal/__init__.py
+++ b/adal/__init__.py
@@ -27,7 +27,7 @@
 
 # pylint: disable=wrong-import-position
 
-__version__ = '0.2.0rc1'
+__version__ = '0.2.3rc1'
 
 import logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
+requests==2.0.0
+PyJWT==1.0.0
+#need 2.x for Python3 support
+python-dateutil==2.1.0
+#1.1.0 is the first that can be installed on windows
+cryptography==1.1.0
+#for testing
 httpretty==0.8.14
-requests==2.10.0
-python-dateutil==2.5.3
-PyJWT==1.4.0
-cryptography==1.3.1
 pylint==1.5.4

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ from setuptools import setup
 
 setup(
     name='adal',
-    version='0.2.0rc1', #note, same string exists in __init__.py
+    version='0.2.3rc1', #note, same string exists in __init__.py
     description=('The ADAL for Python library makes it easy for python ' + 
                  'application to authenticate to Azure Active Directory ' + 
                  '(AAD) in order to access AAD protected web resources.'),
@@ -64,9 +64,9 @@ setup(
     ],
     packages=['adal'],
     install_requires=[
-        'PyJWT',
-        'requests',
-        'python-dateutil',
-        'cryptography'
+        'PyJWT>=1.0.0',
+        'requests>=2.0.0',
+        'python-dateutil>=2.1.0',
+        'cryptography>=1.1.0'
     ]
 )


### PR DESCRIPTION
For requests and pyjwt, set to the one with first major version update.
For dateutil, set to 2.1.0, the first which support both 2.x and 3.x
For  cryptography, pick 1.1 which is the first which can install on windows error free.

Tested windows, osx and linux.