### PR TITLE
Update for US Government and German Government Authority Instances

### DIFF
--- a/adal/constants.py
+++ b/adal/constants.py
@@ -216,7 +216,7 @@ class HttpError(object):
 class AADConstants(object):
 
     WORLD_WIDE_AUTHORITY = 'login.windows.net'
-    WELL_KNOWN_AUTHORITY_HOSTS = ['login.windows.net', 'login.microsoftonline.com', 'login.chinacloudapi.cn', 'login.cloudgovapi.us']
+    WELL_KNOWN_AUTHORITY_HOSTS = ['login.windows.net', 'login.microsoftonline.com', 'login.chinacloudapi.cn', 'login-us.microsoftonline.com', 'login.microsoftonline.de']
     INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE = 'https://{authorize_host}/common/discovery/instance?authorization_endpoint={authorize_endpoint}&api-version=1.0' # pylint: disable=invalid-name
     AUTHORIZE_ENDPOINT_PATH = '/oauth2/authorize'
     TOKEN_ENDPOINT_PATH = '/oauth2/token'

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -124,7 +124,7 @@ class TestAuthority(unittest.TestCase):
         self.performStaticInstanceDiscovery('login.microsoftonline.com')
         self.performStaticInstanceDiscovery('login.windows.net')
         self.performStaticInstanceDiscovery('login.chinacloudapi.cn')
-        self.performStaticInstanceDiscovery('login.cloudgovapi.us')
+        self.performStaticInstanceDiscovery('login-us.microsoftonline.com')
 
 
     @httpretty.activate

--- a/tests/util.py
+++ b/tests/util.py
@@ -126,7 +126,7 @@ parameters = {
     'authorityHosts': {
         'global': 'login.windows.net',
         'china': 'login.chinacloudapi.cn',
-        'gov': 'login.cloudgovapi.us'
+        'gov': 'login-us.microsoftonline.com'
     }
 }
 


### PR DESCRIPTION
This change adds 2 federation providers to the whitelist of federation
providers in the ADAL library
1. The US government one (login-us.microsoftonline.com)
2. The German government one (login.microsoftonline.de)