### PR TITLE
expose ADAL_PYTHON_SSL_NO_VERIFY to skip cert verification 

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 ### Installation
 
 ``` $ pip install adal ```
+
+### http tracing/proxy
+If need to bypass self-signed certificates, turn on the environment variable of `ADAL_PYTHON_SSL_NO_VERIFY`

--- a/adal/authentication_context.py
+++ b/adal/authentication_context.py
@@ -24,7 +24,7 @@
 # THE SOFTWARE.
 #
 #------------------------------------------------------------------------------
-
+import os
 import threading
 
 from .authority import Authority
@@ -66,7 +66,11 @@ class AuthenticationContext(object):
         self.authority = Authority(authority, validate_authority is None or validate_authority)
         self._oauth2client = None
         self.correlation_id = None
-        self._call_context = {'options': GLOBAL_ADAL_OPTIONS}
+        env_value = os.environ.get('ADAL_PYTHON_SSL_NO_VERIFY')
+        self._call_context = {
+            'options': GLOBAL_ADAL_OPTIONS,
+            'verify_ssl': None if env_value is None else not env_value # mainly for tracing through proxy
+            }
         self._token_requests_with_user_code = {}
         self.cache = cache or TokenCache()
         self._lock = threading.RLock()

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -113,7 +113,8 @@ class Authority(object):
         self._log.debug("Attempting instance discover at: %s", discovery_endpoint.geturl())
 
         try:
-            resp = requests.get(discovery_endpoint.geturl(), headers=get_options['headers'])
+            resp = requests.get(discovery_endpoint.geturl(), headers=get_options['headers'],
+                                verify=self._call_context.get('verify_ssl', None))
             util.log_return_correlation_id(self._log, operation, resp)
         except Exception:
             self._log.info("%s request failed", operation)

--- a/adal/mex.py
+++ b/adal/mex.py
@@ -78,7 +78,8 @@ class Mex(object):
 
         try:
             operation = "Mex Get"
-            resp = requests.get(self._url, headers=options['headers'])
+            resp = requests.get(self._url, headers=options['headers'],
+                                verify=self._call_context.get('verify_ssl', None))
             util.log_return_correlation_id(self._log, operation, resp)
         except Exception:
             self._log.info("%s request failed", operation)

--- a/adal/oauth2_client.py
+++ b/adal/oauth2_client.py
@@ -256,7 +256,8 @@ class OAuth2Client(object):
         try:
             resp = requests.post(token_url.geturl(), 
                                  data=url_encoded_token_request, 
-                                 headers=post_options['headers'])
+                                 headers=post_options['headers'],
+                                 verify=self._call_context.get('verify_ssl', None))
 
             util.log_return_correlation_id(self._log, operation, resp)
         except Exception:
@@ -285,7 +286,8 @@ class OAuth2Client(object):
         try:
             resp = requests.post(device_code_url.geturl(), 
                                  data=url_encoded_code_request, 
-                                 headers=post_options['headers'])
+                                 headers=post_options['headers'],
+                                 verify=self._call_context.get('verify_ssl', None))
             util.log_return_correlation_id(self._log, operation, resp)
         except Exception:
             self._log.info("%s request failed", operation)
@@ -320,7 +322,8 @@ class OAuth2Client(object):
 
             resp = requests.post(
                 token_url.geturl(), 
-                data=url_encoded_code_request, headers=post_options['headers'])
+                data=url_encoded_code_request, headers=post_options['headers'],
+                verify=self._call_context.get('verify_ssl', None))
 
             util.log_return_correlation_id(self._log, operation, resp)
 

--- a/adal/user_realm.py
+++ b/adal/user_realm.py
@@ -134,7 +134,8 @@ class UserRealm(object):
                         user_realm_url.geturl())
 
         operation = 'User Realm Discovery'
-        resp = requests.get(user_realm_url.geturl(), headers=options['headers'])
+        resp = requests.get(user_realm_url.geturl(), headers=options['headers'],
+                            verify=self._call_context.get('verify_ssl', None))
         util.log_return_correlation_id(self._log, operation, resp)
 
         if not util.is_http_success(resp.status_code):

--- a/adal/wstrust_request.py
+++ b/adal/wstrust_request.py
@@ -142,7 +142,8 @@ class WSTrustRequest(object):
         self._log.debug("Sending RST to: %s", self._wstrust_endpoint_url)
 
         operation = "WS-Trust RST"
-        resp = requests.post(self._wstrust_endpoint_url, headers=options['headers'], data=rst, allow_redirects=True)
+        resp = requests.post(self._wstrust_endpoint_url, headers=options['headers'], data=rst,
+                             allow_redirects=True, verify=self._call_context.get('verify_ssl', None))
 
         util.log_return_correlation_id(self._log, operation, resp)
 


### PR DESCRIPTION
Mainly for tracing through proxy