### PR TITLE
fix encoding error when format error text (python 2.7 only)

### DIFF
--- a/adal/authority.py
+++ b/adal/authority.py
@@ -121,11 +121,12 @@ class Authority(object):
             raise
 
         if not util.is_http_success(resp.status_code):
-            return_error_string = "{} request returned http error: {}".format(operation, 
-                                                                              resp.status_code)
+            return_error_string = u"{} request returned http error: {}".format(operation, 
+                                                                               resp.status_code)
             error_response = ""
             if resp.text:
-                return_error_string += " and server response: {}".format(resp.text)
+                return_error_string = u"{} and server response: {}".format(return_error_string,
+                                                                           resp.text)
                 try:
                     error_response = resp.json()
                 except ValueError:

--- a/adal/mex.py
+++ b/adal/mex.py
@@ -86,10 +86,10 @@ class Mex(object):
             raise
 
         if not util.is_http_success(resp.status_code):
-            return_error_string = "{} request returned http error: {}".format(operation, resp.status_code)
+            return_error_string = u"{} request returned http error: {}".format(operation, resp.status_code)
             error_response = ""
             if resp.text:
-                return_error_string += " and server response: {}".format(resp.text)
+                return_error_string = u"{} and server response: {}".format(return_error_string, resp.text)
                 try:
                     error_response = resp.json()
                 except ValueError:

--- a/adal/oauth2_client.py
+++ b/adal/oauth2_client.py
@@ -58,7 +58,7 @@ TOKEN_RESPONSE_MAP = {
 }
 
 _REQ_OPTION = {'headers' : {'content-type': 'application/x-www-form-urlencoded'}}
-_ERROR_TEMPLATE = "{} request returned http error: {}"
+_ERROR_TEMPLATE = u"{} request returned http error: {}"
 
 
 def map_fields(in_obj, map_to):
@@ -270,7 +270,8 @@ class OAuth2Client(object):
             return_error_string = _ERROR_TEMPLATE.format(operation, resp.status_code)
             error_response = ""
             if resp.text:
-                return_error_string += " and server response: {}".format(resp.text)
+                return_error_string = u"{} and server response: {}".format(return_error_string,
+                                                                           resp.text)
                 try:
                     error_response = resp.json()
                 except ValueError:
@@ -299,7 +300,8 @@ class OAuth2Client(object):
             return_error_string = _ERROR_TEMPLATE.format(operation, resp.status_code)
             error_response = ""
             if resp.text:
-                return_error_string += " and server response: {}".format(resp.text)
+                return_error_string = u"{} and server response: {}".format(return_error_string,
+                                                                           resp.text)
                 try:
                     error_response = resp.json()
                 except ValueError:
@@ -343,7 +345,7 @@ class OAuth2Client(object):
                 try:
                     return self._validate_token_response(resp.text)
                 except Exception: 
-                    self._log.info("Error validating get token response '%s'",
+                    self._log.info(u"Error validating get token response '%s'",
                                    resp.text)
                     raise
 

--- a/adal/user_realm.py
+++ b/adal/user_realm.py
@@ -139,11 +139,11 @@ class UserRealm(object):
         util.log_return_correlation_id(self._log, operation, resp)
 
         if not util.is_http_success(resp.status_code):
-            return_error_string = "{} request returned http error: {}".format(operation, 
-                                                                              resp.status_code)
+            return_error_string = u"{} request returned http error: {}".format(operation, 
+                                                                               resp.status_code)
             error_response = ""
             if resp.text:
-                return_error_string += " and server response: {}".format(resp.text)
+                return_error_string = u"{} and server response: {}".format(return_error_string, resp.text)
                 try:
                     error_response = resp.json()
                 except ValueError:

--- a/adal/wstrust_request.py
+++ b/adal/wstrust_request.py
@@ -148,10 +148,10 @@ class WSTrustRequest(object):
         util.log_return_correlation_id(self._log, operation, resp)
 
         if not util.is_http_success(resp.status_code):
-            return_error_string = "{} request returned http error: {}".format(operation, resp.status_code)
+            return_error_string = u"{} request returned http error: {}".format(operation, resp.status_code)
             error_response = ""
             if resp.text:
-                return_error_string += " and server response: {}".format(resp.text)
+                return_error_string = u"{} and server response: {}".format(return_error_string, resp.text)
                 try:
                     error_response = resp.json()
                 except ValueError:


### PR DESCRIPTION
The real error was hidden under the exception of `'ascii' codes can't encode character u'\xa0' in position 150: ordinal not in range(128)`. This is confusing