### PR TITLE
Fix Logger to preserve kwargs struct

### DIFF
--- a/adal/log.py
+++ b/adal/log.py
@@ -79,7 +79,7 @@ class Logger(object):
         self.log_context = log_context
         self._logging = logging.getLogger(ADAL_LOGGER_NAME)
 
-    def _log_message(self, msg, **kwargs):
+    def _log_message(self, msg, kwargs):
         log_stack_trace = False
         if 'log_stack_trace' in kwargs:
             log_stack_trace = kwargs['log_stack_trace']
@@ -98,13 +98,13 @@ class Logger(object):
         return formatted
 
     def warn(self, msg, *args, **kwargs):
-        msg = self._log_message(msg, **kwargs)
+        msg = self._log_message(msg, kwargs)
         self._logging.warning(msg, *args, **kwargs)
 
     def info(self, msg, *args, **kwargs):
-        msg = self._log_message(msg, **kwargs)
+        msg = self._log_message(msg, kwargs)
         self._logging.info(msg, *args, **kwargs)
 
     def debug(self, msg, *args, **kwargs):
-        msg = self._log_message(msg, **kwargs)
+        msg = self._log_message(msg, kwargs)
         self._logging.debug(msg, *args, **kwargs)


### PR DESCRIPTION
In Python 2.7, passing kwargs as keywords to _log_message() doesn't guarantee that the data structure inside the function will be the same as outside, thus causing kwargs.pop to not operate on the right object.
  ...
  File "adal/token_request.py", line 277, in get_token_with_username_password
    log_stack_trace=True)
  File "adal/log.py", line 102, in warn
    self._logging.warning(msg, _args, *_kwargs)
  File "/usr/lib64/python2.7/logging/__init__.py", line 1179, in warning
    self._log(WARNING, msg, args, **kwargs)
TypeError: _log() got an unexpected keyword argument 'log_stack_trace'

Fixed by changing _log_message() to accept kwargs as an object.
