### PR TITLE
Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
 install:
   - pip install -r requirements.txt
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
-script: 
-  - pylint adal
-  - python -m unittest discover -s tests 
+script:
+  - # PyLint does not yet support Python 3.6 https://github.com/PyCQA/pylint/issues/1241
+    if [ "$TRAVIS_PYTHON_VERSION" != "3.6" ]; then
+      pylint adal;
+    fi
+  - python -m unittest discover -s tests

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: MIT License',
     ],
     packages=['adal'],


### PR DESCRIPTION
[Python 3.6 has been officially released](https://www.python.org/downloads/release/python-360/). We are now examining our code on Python 3.6. All test cases in our current code base actually pass on Python 3.6, however the Travis-CI test jobs failed due to the source code style checker [PyLint does not yet support Python 3.6](https://github.com/PyCQA/pylint/issues/1241). We don't have to run PyLint on every Python platform so, as a quick workaround, let's bypass it for now.