### PR TITLE
Don't hardcode API version to 1.0 to avoid deprecation warning.

### DIFF
--- a/adal/authentication_context.py
+++ b/adal/authentication_context.py
@@ -47,7 +47,7 @@ class AuthenticationContext(object):
 
     def __init__(
             self, authority, validate_authority=None, cache=None,
-            api_version='1.0'):
+            api_version=None):
         '''Creates a new AuthenticationContext object.
 
         By default the authority will be checked against a list of known Azure


### PR DESCRIPTION
There doesn't appear to be any way to avoid a deprecation warning, evening if setting API version to None when calling authenticationContext because it is hardcoded to 1.0. In that case either hardcode it to None now, or don't set it.