### PR TITLE
Corrected usage in comment of sample code

### DIFF
--- a/sample/certificate_credentials_sample.py
+++ b/sample/certificate_credentials_sample.py
@@ -6,11 +6,11 @@ import adal
 
 def turn_on_logging():
     logging.basicConfig(level=logging.DEBUG)
-    #or, 
+    #or,
     #handler = logging.StreamHandler()
     #adal.set_logging_options({
     #    'level': 'DEBUG',
-    #    'handler': handler 
+    #    'handler': handler
     #})
     #handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
 
@@ -20,8 +20,8 @@ def get_private_key(filename):
     return private_pem
 
 #
-# You can provide account information by using a JSON file. Either 
-# through a command line argument, 'python sample.js parameters.json', or
+# You can provide account information by using a JSON file. Either
+# through a command line argument, 'python sample.py parameters.json', or
 # specifying in an environment variable of ADAL_SAMPLE_PARAMETERS_FILE.
 # privateKeyFile must contain a PEM encoded cert with private key.
 # thumbprint must be the thumbprint of the privateKeyFile.
@@ -32,7 +32,7 @@ def get_private_key(filename):
 #   "thumbprint" : 'C15DEA8656ADDF67BE8031D85EBDDC5AD6C436E1',
 #   "privateKeyFile" : 'ncwebCTKey.pem'
 # }
-parameters_file = (sys.argv[1] if len(sys.argv) == 2 else 
+parameters_file = (sys.argv[1] if len(sys.argv) == 2 else
                    os.environ.get('ADAL_SAMPLE_PARAMETERS_FILE'))
 sample_parameters = {}
 if parameters_file:
@@ -43,7 +43,7 @@ else:
     raise ValueError('Please provide parameter file with account information.')
 
 
-authority_url = (sample_parameters['authorityHostUrl'] + '/' + 
+authority_url = (sample_parameters['authorityHostUrl'] + '/' +
                  sample_parameters['tenant'])
 RESOURCE = '00000002-0000-0000-c000-000000000000'
 
@@ -54,9 +54,9 @@ context = adal.AuthenticationContext(authority_url)
 key = get_private_key(sample_parameters['privateKeyFile'])
 
 token = context.acquire_token_with_client_certificate(
-    RESOURCE, 
-    sample_parameters['clientId'], 
-    key, 
+    RESOURCE,
+    sample_parameters['clientId'],
+    key,
     sample_parameters['thumbprint'])
 
 print('Here is the token:')

--- a/sample/client_credentials_sample.py
+++ b/sample/client_credentials_sample.py
@@ -6,16 +6,16 @@ import adal
 
 def turn_on_logging():
     logging.basicConfig(level=logging.DEBUG)
-    #or, 
+    #or,
     #handler = logging.StreamHandler()
     #adal.set_logging_options({
     #    'level': 'DEBUG',
-    #    'handler': handler 
+    #    'handler': handler
     #})
     #handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
 
 # You can provide account information by using a JSON file. Either
-# through a command line argument, 'python sample.js parameters.json', or
+# through a command line argument, 'python sample.py parameters.json', or
 # specifying in an environment variable of ADAL_SAMPLE_PARAMETERS_FILE.
 # {
 #    "tenant" : "rrandallaad1.onmicrosoft.com",
@@ -24,7 +24,7 @@ def turn_on_logging():
 #    "clientSecret" : "verySecret=""
 # }
 
-parameters_file = (sys.argv[1] if len(sys.argv) == 2 else 
+parameters_file = (sys.argv[1] if len(sys.argv) == 2 else
                    os.environ.get('ADAL_SAMPLE_PARAMETERS_FILE'))
 
 if parameters_file:
@@ -33,8 +33,8 @@ if parameters_file:
     sample_parameters = json.loads(parameters)
 else:
     raise ValueError('Please provide parameter file with account information.')
-    
-authority_url = (sample_parameters['authorityHostUrl'] + '/' + 
+
+authority_url = (sample_parameters['authorityHostUrl'] + '/' +
                  sample_parameters['tenant'])
 RESOURCE = '00000002-0000-0000-c000-000000000000'
 
@@ -45,7 +45,7 @@ context = adal.AuthenticationContext(authority_url)
 
 token = context.acquire_token_with_client_credentials(
     RESOURCE,
-    sample_parameters['clientId'], 
+    sample_parameters['clientId'],
     sample_parameters['clientSecret'])
 
 print('Here is the token:')

--- a/sample/device_code_sample.py
+++ b/sample/device_code_sample.py
@@ -6,17 +6,17 @@ import adal
 
 def turn_on_logging():
     logging.basicConfig(level=logging.DEBUG)
-    #or, 
+    #or,
     #handler = logging.StreamHandler()
     #adal.set_logging_options({
     #    'level': 'DEBUG',
-    #    'handler': handler 
+    #    'handler': handler
     #})
     #handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
 
 # You can provide account information by using a JSON file
 # with the same parameters as the sampleParameters variable below.  Either
-# through a command line argument, 'python sample.js parameters.json', or
+# through a command line argument, 'python sample.py parameters.json', or
 # specifying in an environment variable of ADAL_SAMPLE_PARAMETERS_FILE.
 # {
 #    "tenant" : "rrandallaad1.onmicrosoft.com",
@@ -25,7 +25,7 @@ def turn_on_logging():
 #    "anothertenant" : "bar.onmicrosoft.com"
 # }
 
-parameters_file = (sys.argv[1] if len(sys.argv) == 2 else 
+parameters_file = (sys.argv[1] if len(sys.argv) == 2 else
                    os.environ.get('ADAL_SAMPLE_PARAMETERS_FILE'))
 
 if parameters_file:
@@ -41,7 +41,7 @@ authority_url = authority_host_url + '/' + sample_parameters['tenant']
 clientid = sample_parameters['clientid']
 RESOURCE = '00000002-0000-0000-c000-000000000000'
 
-#uncomment for verbose logging 
+#uncomment for verbose logging
 #turn_on_logging()
 
 context = adal.AuthenticationContext(authority_url)
@@ -56,7 +56,7 @@ print(json.dumps(token, indent=2))
 another_tenant = sample_parameters.get('anothertenant')
 if another_tenant:
     authority_url = authority_host_url + '/' + another_tenant
-    #reuse existing cache which has the tokens acquired early on 
+    #reuse existing cache which has the tokens acquired early on
     existing_cache = context.cache
     context = adal.AuthenticationContext(authority_url, cache=existing_cache)
     token = context.acquire_token(RESOURCE, token['userId'], clientid)

--- a/sample/refresh_token_sample.py
+++ b/sample/refresh_token_sample.py
@@ -6,16 +6,16 @@ import adal
 
 def turn_on_logging():
     logging.basicConfig(level=logging.DEBUG)
-    #or, 
+    #or,
     #handler = logging.StreamHandler()
     #adal.set_logging_options({
     #    'level': 'DEBUG',
-    #    'handler': handler 
+    #    'handler': handler
     #})
     #handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
 
 # You can override the account information by using a JSON file. Either
-# through a command line argument, 'python sample.js parameters.json', or
+# through a command line argument, 'python sample.py parameters.json', or
 # specifying in an environment variable of ADAL_SAMPLE_PARAMETERS_FILE.
 # {
 #   "tenant" : "rrandallaad1.onmicrosoft.com",
@@ -25,7 +25,7 @@ def turn_on_logging():
 #   "password" : "verySecurePassword"
 # }
 
-parameters_file = (sys.argv[1] if len(sys.argv) == 2 else 
+parameters_file = (sys.argv[1] if len(sys.argv) == 2 else
                    os.environ.get('ADAL_SAMPLE_PARAMETERS_FILE'))
 
 if parameters_file:
@@ -35,7 +35,7 @@ if parameters_file:
 else:
     raise ValueError('Please provide parameter file with account information.')
 
-authority_url = (sample_parameters['authorityHostUrl'] + '/' + 
+authority_url = (sample_parameters['authorityHostUrl'] + '/' +
                  sample_parameters['tenant'])
 RESOURCE = '00000002-0000-0000-c000-000000000000'
 
@@ -45,7 +45,7 @@ RESOURCE = '00000002-0000-0000-c000-000000000000'
 context = adal.AuthenticationContext(authority_url)
 
 token = context.acquire_token_with_username_password(
-    RESOURCE, 
+    RESOURCE,
     sample_parameters['username'],
     sample_parameters['password'],
     sample_parameters['clientid'])

--- a/sample/website_sample.py
+++ b/sample/website_sample.py
@@ -1,4 +1,4 @@
-﻿try: 
+﻿try:
     from http import server as httpserver
     from http import cookies as Cookie
 except ImportError:
@@ -24,7 +24,7 @@ import sys
 from adal import AuthenticationContext
 
 # You can provide account information by using a JSON file. Either
-# through a command line argument, 'python sample.js parameters.json', or
+# through a command line argument, 'python sample.py parameters.json', or
 # specifying in an environment variable of ADAL_SAMPLE_PARAMETERS_FILE.
 # {
 #    "tenant" : "rrandallaad1.onmicrosoft.com",
@@ -33,7 +33,7 @@ from adal import AuthenticationContext
 #    "clientSecret" : "verySecret=""
 # }
 
-parameters_file = (sys.argv[1] if len(sys.argv) == 2 else 
+parameters_file = (sys.argv[1] if len(sys.argv) == 2 else
                    os.environ.get('ADAL_SAMPLE_PARAMETERS_FILE'))
 
 if parameters_file:
@@ -44,13 +44,13 @@ else:
     raise ValueError('Please provide parameter file with account information.')
 
 PORT = 8088
-TEMPLATE_AUTHZ_URL = ('https://login.windows.net/{}/oauth2/authorize?'+ 
+TEMPLATE_AUTHZ_URL = ('https://login.windows.net/{}/oauth2/authorize?'+
                       'response_type=code&client_id={}&redirect_uri={}&'+
                       'state={}&resource={}')
 RESOURCE = '00000002-0000-0000-c000-000000000000' #Graph Resource
 REDIRECT_URI = 'http://localhost:{}/getAToken'.format(PORT)
 
-authority_url = (sample_parameters['authorityHostUrl'] + '/' + 
+authority_url = (sample_parameters['authorityHostUrl'] + '/' +
                  sample_parameters['tenant'])
 
 class OAuth2RequestHandler(httpserver.SimpleHTTPRequestHandler):
@@ -61,16 +61,16 @@ class OAuth2RequestHandler(httpserver.SimpleHTTPRequestHandler):
             self.send_header('Location', login_url)
             self.end_headers()
         elif self.path == '/login':
-            auth_state = (''.join(random.SystemRandom() 
+            auth_state = (''.join(random.SystemRandom()
                                   .choice(string.ascii_uppercase + string.digits)
                                   for _ in range(48)))
             cookie = Cookie.SimpleCookie()
             cookie['auth_state'] = auth_state
             authorization_url = TEMPLATE_AUTHZ_URL.format(
-                sample_parameters['tenant'], 
-                sample_parameters['clientId'], 
-                REDIRECT_URI, 
-                auth_state, 
+                sample_parameters['tenant'],
+                sample_parameters['clientId'],
+                REDIRECT_URI,
+                auth_state,
                 RESOURCE)
             self.send_response(307)
             self.send_header('Set-Cookie', cookie.output(header=''))
@@ -88,13 +88,13 @@ class OAuth2RequestHandler(httpserver.SimpleHTTPRequestHandler):
                     sample_parameters['clientId'],
                     RESOURCE,
                     sample_parameters['clientSecret'])
-                message = (message + '*** And here is the refresh response:' + 
+                message = (message + '*** And here is the refresh response:' +
                            json.dumps(token_response))
             except ValueError as exp:
                 message = str(exp)
                 is_ok = False
             self._send_response(message, is_ok)
-    
+
     def _acquire_token(self):
         parsed = urlparse(self.path)
         code = parse_qs(parsed.query)['code'][0]
@@ -104,10 +104,10 @@ class OAuth2RequestHandler(httpserver.SimpleHTTPRequestHandler):
             raise ValueError('state does not match')
         auth_context = AuthenticationContext(authority_url)
         return auth_context.acquire_token_with_authorization_code(
-            code, 
-            REDIRECT_URI, 
-            RESOURCE, 
-            sample_parameters['clientId'], 
+            code,
+            REDIRECT_URI,
+            RESOURCE,
+            sample_parameters['clientId'],
             sample_parameters['clientSecret'])
 
     def _send_response(self, message, is_ok=True):


### PR DESCRIPTION
Usage in the sample codes comment stated `python sample.js parameters.json`.  Updated to read `python sample.py parameters.json`.