### PR TITLE
Fixes platform resolution issue in Gunicorn/Gevent context

### DIFF
--- a/adal/util.py
+++ b/adal/util.py
@@ -55,11 +55,7 @@ def add_default_request_headers(self, options):
     headers[AdalIdParameters.SKU] = AdalIdParameters.PYTHON_SKU
     headers[AdalIdParameters.VERSION] = adal.__version__
     headers[AdalIdParameters.OS] = sys.platform
-
-    try:
-        headers[AdalIdParameters.CPU] = 'x64' if platform.architecture()[0] == '64bit' else 'x86'
-    except:
-        headers[AdalIdParameters.CPU] = 'unknown'
+    headers[AdalIdParameters.CPU] = 'x64' if sys.maxsize > 2 ** 32 else 'x86'
 
 def create_request_options(self, *options):
 

--- a/adal/util.py
+++ b/adal/util.py
@@ -55,7 +55,11 @@ def add_default_request_headers(self, options):
     headers[AdalIdParameters.SKU] = AdalIdParameters.PYTHON_SKU
     headers[AdalIdParameters.VERSION] = adal.__version__
     headers[AdalIdParameters.OS] = sys.platform
-    headers[AdalIdParameters.CPU] = 'x64' if platform.architecture()[0] == '64bit' else 'x86'
+
+    try:
+        headers[AdalIdParameters.CPU] = 'x64' if platform.architecture()[0] == '64bit' else 'x86'
+    except:
+        headers[AdalIdParameters.CPU] = 'unknown'
 
 def create_request_options(self, *options):
 

--- a/adal/util.py
+++ b/adal/util.py
@@ -26,7 +26,6 @@
 #------------------------------------------------------------------------------
 
 import sys
-import platform
 import base64
 try:
     from urllib.parse import urlparse


### PR DESCRIPTION
Sets the platform header to 'unknown' in case of an exception during the architecture resolution call. Tested the fix in a Gunicorn environment.

UPDATE: Since the issue is caused by `platform.architecture(...)` fails on Gunicorn environment, we end up using an [alternative way](https://docs.python.org/3/library/platform.html#cross-platform) to detect.