### PR TITLE
Demonstrating how ADAL supports ADFS-only scenario

### DIFF
--- a/sample/client_credentials_sample.py
+++ b/sample/client_credentials_sample.py
@@ -18,6 +18,7 @@ def turn_on_logging():
 # through a command line argument, 'python sample.js parameters.json', or
 # specifying in an environment variable of ADAL_SAMPLE_PARAMETERS_FILE.
 # {
+#    "resource": "your_resource",
 #    "tenant" : "rrandallaad1.onmicrosoft.com",
 #    "authorityHostUrl" : "https://login.microsoftonline.com",
 #    "clientId" : "624ac9bd-4c1c-4687-aec8-b56a8991cfb3",
@@ -36,12 +37,14 @@ else:
     
 authority_url = (sample_parameters['authorityHostUrl'] + '/' + 
                  sample_parameters['tenant'])
-RESOURCE = '00000002-0000-0000-c000-000000000000'
+RESOURCE = sample_parameters.get(
+    'resource', '00000002-0000-0000-c000-000000000000')
 
 #uncomment for verbose log
 #turn_on_logging()
 
-context = adal.AuthenticationContext(authority_url)
+context = adal.AuthenticationContext(
+    authority_url, validate_authority=sample_parameters['tenant'] != 'adfs')
 
 token = context.acquire_token_with_client_credentials(
     RESOURCE,

--- a/sample/refresh_token_sample.py
+++ b/sample/refresh_token_sample.py
@@ -18,6 +18,7 @@ def turn_on_logging():
 # through a command line argument, 'python sample.js parameters.json', or
 # specifying in an environment variable of ADAL_SAMPLE_PARAMETERS_FILE.
 # {
+#   "resource": "your_resource",
 #   "tenant" : "rrandallaad1.onmicrosoft.com",
 #   "authorityHostUrl" : "https://login.microsoftonline.com",
 #   "clientid" : "624ac9bd-4c1c-4687-aec8-b56a8991cfb3",
@@ -37,12 +38,14 @@ else:
 
 authority_url = (sample_parameters['authorityHostUrl'] + '/' + 
                  sample_parameters['tenant'])
-RESOURCE = '00000002-0000-0000-c000-000000000000'
+RESOURCE = sample_parameters.get(
+    'resource', '00000002-0000-0000-c000-000000000000')
 
 #uncomment for verbose log
 #turn_on_logging()
 
-context = adal.AuthenticationContext(authority_url)
+context = adal.AuthenticationContext(
+    authority_url, validate_authority=sample_parameters['tenant'] != 'adfs')
 
 token = context.acquire_token_with_username_password(
     RESOURCE, 


### PR DESCRIPTION
You just need to disable authority validation.

These have been tested on an AD FS 2016 server.