### PR TITLE
Forcing utf8 decoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,12 @@
 #------------------------------------------------------------------------------
 
 from setuptools import setup
-import re
+import re, io
 
 # setup.py shall not import adal
 __version__ = re.search(
     r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]',  # It excludes inline comment too
-    open('adal/__init__.py').read()).group(1)
+    io.open('adal/__init__.py', encoding='utf8').read()).group(1)
 
 # To build:
 # python setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ import re, io
 # setup.py shall not import adal
 __version__ = re.search(
     r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]',  # It excludes inline comment too
-    io.open('adal/__init__.py', encoding='utf8').read()).group(1)
+    io.open('adal/__init__.py', encoding='utf_8_sig').read()
+    ).group(1)
 
 # To build:
 # python setup.py sdist


### PR DESCRIPTION
Otherwise some locale uses default ascii decoding and can not handle BOM.

This PR fixes #89, and already tested by its reporter @glaubitz . This fix will allow him to build a RPM package and that will drive our adoption in the community.