### PR TITLE
Remove outdated code snippets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,71 +30,20 @@ For more context, starts with this [stackoverflow thread](http://stackoverflow.c
 
 In order to use this token acquisition method, you need to configure a service principal. Please follow [this walkthrough](https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/).
 
-See the [sample](./sample/client_credentials_sample.py).
-```python
-import adal
-
-context = adal.AuthenticationContext('https://login.microsoftonline.com/ABCDEFGH-1234-1234-1234-ABCDEFGHIJKL')
-RESOURCE = '00000002-0000-0000-c000-000000000000' #AAD graph resource
-token = context.acquire_token_with_client_credentials(
-    RESOURCE,
-    "http://PythonSDK", 
-    "Key-Configured-In-Portal")
-```
+See the [sample](sample/client_credentials_sample.py#L46-L53).
 
 ### Acquire Token with client certificate
-A service principal is also required. See the [sample](./sample/certificate_credentials_sample.py).
-```python
-import adal
-context = adal.AuthenticationContext('https://login.microsoftonline.com/ABCDEFGH-1234-1234-1234-ABCDEFGHIJKL')
-RESOURCE = '00000002-0000-0000-c000-000000000000' #AAD graph resource
-token = context.acquire_token_with_client_certificate(
-    RESOURCE,
-    "http://PythonSDK",  
-    'yourPrivateKeyFileContent', 
-    'thumbprintOfPrivateKey')
-```
+A service principal is also required. See the [sample](sample/certificate_credentials_sample.py#L55-L62).
 
 ### Acquire Token with Refresh Token
-See the [sample](./sample/refresh_token_sample.py).
-```python
-import adal
-context = adal.AuthenticationContext('https://login.microsoftonline.com/ABCDEFGH-1234-1234-1234-ABCDEFGHIJKL')
-RESOURCE = '00000002-0000-0000-c000-000000000000' #AAD graph resource
-token = context.acquire_token_with_username_password(
-    RESOURCE, 
-    'yourName',
-    'yourPassword',
-    'yourClientIdHere')
-
-refresh_token = token['refreshToken']
-token = context.acquire_token_with_refresh_token(
-    refresh_token,
-    'yourClientIdHere',
-    RESOURCE)
-```
+See the [sample](sample/refresh_token_sample.py#L47-L64).
 
 ### Acquire Token with device code
-See the [sample](./sample/device_code_sample.py).
-```python
-context = adal.AuthenticationContext('https://login.microsoftonline.com/ABCDEFGH-1234-1234-1234-ABCDEFGHIJKL')
-RESOURCE = '00000002-0000-0000-c000-000000000000' #AAD graph resource
-code = context.acquire_user_code(RESOURCE, 'yourClientIdHere')
-print(code['message'])
-token = context.acquire_token_with_device_code(RESOURCE, code, 'yourClientIdHere')
-``` 
+See the [sample](sample/device_code_sample.py#L49-L52).
+
 ### Acquire Token with authorization code
-See the [sample](./sample/website_sample.py) for a complete bare bones web site that makes use of the code below.
-```python
-context = adal.AuthenticationContext('https://login.microsoftonline.com/ABCDEFGH-1234-1234-1234-ABCDEFGHIJKL')
-RESOURCE = '00000002-0000-0000-c000-000000000000' #AAD graph resource
-return context.acquire_token_with_authorization_code(
-            'yourCodeFromQueryString', 
-            'yourWebRedirectUri', 
-            RESOURCE, 
-            'yourClientId', 
-            'yourClientSecret')
-``` 
+See the [sample](sample/website_sample.py#L107-L113) for a complete bare bones web site that makes use of the code below.
+
 
 ## Samples and Documentation
 We provide a full suite of [sample applications on GitHub](https://github.com/azure-samples?utf8=%E2%9C%93&q=active-directory&type=&language=) and an [Azure AD developer landing page](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-developers-guide) to help you get started with learning the Azure Identity system. This includes tutorials for native clients and web applications. We also provide full walkthroughs for authentication flows such as OAuth2, OpenID Connect and for calling APIs such as the Graph API.

--- a/README.md
+++ b/README.md
@@ -30,19 +30,20 @@ For more context, starts with this [stackoverflow thread](http://stackoverflow.c
 
 In order to use this token acquisition method, you need to configure a service principal. Please follow [this walkthrough](https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/).
 
-See the [sample](sample/client_credentials_sample.py#L46-L53).
+Find the `Main logic` part in the [sample](sample/client_credentials_sample.py#L46-L55).
 
 ### Acquire Token with client certificate
-A service principal is also required. See the [sample](sample/certificate_credentials_sample.py#L55-L62).
+A service principal is also required.
+Find the `Main logic` part in the [sample](sample/certificate_credentials_sample.py#L55-L64).
 
 ### Acquire Token with Refresh Token
-See the [sample](sample/refresh_token_sample.py#L47-L64).
+Find the `Main logic` part in the [sample](sample/refresh_token_sample.py#L47-L66).
 
 ### Acquire Token with device code
-See the [sample](sample/device_code_sample.py#L49-L52).
+Find the `Main logic` part in the [sample](sample/device_code_sample.py#L49-L54).
 
 ### Acquire Token with authorization code
-See the [sample](sample/website_sample.py#L107-L113) for a complete bare bones web site that makes use of the code below.
+Find the `Main logic` part in the [sample](sample/website_sample.py#L107-L115) for a complete bare bones web site that makes use of the code below.
 
 
 ## Samples and Documentation

--- a/sample/certificate_credentials_sample.py
+++ b/sample/certificate_credentials_sample.py
@@ -52,6 +52,7 @@ RESOURCE = sample_parameters.get('resource', GRAPH_RESOURCE)
 #uncomment for verbose logging
 turn_on_logging()
 
+### Main logic begins
 context = adal.AuthenticationContext(authority_url, api_version=None)
 key = get_private_key(sample_parameters['privateKeyFile'])
 
@@ -60,6 +61,7 @@ token = context.acquire_token_with_client_certificate(
     sample_parameters['clientId'],
     key,
     sample_parameters['thumbprint'])
+### Main logic ends
 
 print('Here is the token:')
 print(json.dumps(token, indent=2))

--- a/sample/client_credentials_sample.py
+++ b/sample/client_credentials_sample.py
@@ -43,6 +43,7 @@ RESOURCE = sample_parameters.get('resource', GRAPH_RESOURCE)
 #uncomment for verbose log
 #turn_on_logging()
 
+### Main logic begins
 context = adal.AuthenticationContext(
     authority_url, validate_authority=sample_parameters['tenant'] != 'adfs',
     api_version=None)
@@ -51,6 +52,7 @@ token = context.acquire_token_with_client_credentials(
     RESOURCE,
     sample_parameters['clientId'],
     sample_parameters['clientSecret'])
+### Main logic ends
 
 print('Here is the token:')
 print(json.dumps(token, indent=2))

--- a/sample/device_code_sample.py
+++ b/sample/device_code_sample.py
@@ -46,10 +46,12 @@ RESOURCE = sample_parameters.get('resource', GRAPH_RESOURCE)
 #uncomment for verbose logging
 #turn_on_logging()
 
+### Main logic begins
 context = adal.AuthenticationContext(authority_url, api_version=None)
 code = context.acquire_user_code(RESOURCE, clientid)
 print(code['message'])
 token = context.acquire_token_with_device_code(RESOURCE, code, clientid)
+### Main logic ends
 
 print('Here is the token from "{}":'.format(authority_url))
 print(json.dumps(token, indent=2))

--- a/sample/refresh_token_sample.py
+++ b/sample/refresh_token_sample.py
@@ -44,6 +44,7 @@ RESOURCE = sample_parameters.get('resource', GRAPH_RESOURCE)
 #uncomment for verbose log
 #turn_on_logging()
 
+### Main logic begins
 context = adal.AuthenticationContext(
     authority_url, validate_authority=sample_parameters['tenant'] != 'adfs',
     api_version=None)
@@ -62,6 +63,7 @@ token = context.acquire_token_with_refresh_token(
     refresh_token,
     sample_parameters['clientid'],
     RESOURCE)
+### Main logic ends
 
 print('Here is the token acquired from the refreshing token')
 print(json.dumps(token, indent=2))

--- a/sample/website_sample.py
+++ b/sample/website_sample.py
@@ -104,6 +104,7 @@ class OAuth2RequestHandler(httpserver.SimpleHTTPRequestHandler):
         cookie = Cookie.SimpleCookie(self.headers["Cookie"])
         if state != cookie['auth_state'].value:
             raise ValueError('state does not match')
+        ### Main logic begins
         auth_context = AuthenticationContext(authority_url, api_version=None)
         return auth_context.acquire_token_with_authorization_code(
             code,
@@ -111,6 +112,7 @@ class OAuth2RequestHandler(httpserver.SimpleHTTPRequestHandler):
             RESOURCE,
             sample_parameters['clientId'],
             sample_parameters['clientSecret'])
+        ### Main logic ends
 
     def _send_response(self, message, is_ok=True):
         self.send_response(200 if is_ok else 400)


### PR DESCRIPTION
And guide readers to the runnable samples.

The reason of this change is that,  [we used to have ONLY those code snippets in README but WITHOUT any real samples](https://github.com/AzureAD/azure-activedirectory-library-for-python/tree/903448df0efbfc63ae31d7dcd940f88cbed15f01). Later we [added real samples and modified readme to include links to those samples](https://github.com/AzureAD/azure-activedirectory-library-for-python/pull/13/files). This opened the door for the 2 copies of information becoming out of sync. In practice, we the maintainers pay more attention on real samples because they are runnable and we used them to test all the time, and we sometimes overlook the README. This kind of out-of-sync README could be [costy](https://github.com/AzureAD/azure-activedirectory-library-for-python/pull/102#issue-248141711). This PR removes duplicate (and outdated) information in README, and solves the problem once and for all.

CC @linzhp