### PR TITLE
Handle token refresh in Azure Stack (ADFS 2016) 

### DIFF
--- a/adal/cache_driver.py
+++ b/adal/cache_driver.py
@@ -132,6 +132,10 @@ class CacheDriver(object):
         new_entry = copy.deepcopy(entry)
         new_entry.update(refresh_response)
 
+        # for ADFS, it is possible the response payload has no 'resource' field, so we add it
+        if 'resource' not in refresh_response:
+            new_entry['resource'] = self._resource
+
         if entry[TokenResponseFields.IS_MRRT] and self._authority != entry[TokenResponseFields._AUTHORITY]:
             new_entry[TokenResponseFields._AUTHORITY] = self._authority
 

--- a/adal/cache_driver.py
+++ b/adal/cache_driver.py
@@ -132,7 +132,9 @@ class CacheDriver(object):
         new_entry = copy.deepcopy(entry)
         new_entry.update(refresh_response)
 
-        # for ADFS, it is possible the response payload has no 'resource' field, so we add it
+        # It is possible the response payload has no 'resource' field, like in ADFS, so we manually 
+        # fill it here. Note, 'resource' is part of the token cache key, so we have to set it to avoid
+        # corrupting the cache.
         if 'resource' not in refresh_response:
             new_entry['resource'] = self._resource
 

--- a/tests/test_refresh_token.py
+++ b/tests/test_refresh_token.py
@@ -67,5 +67,20 @@ class TestRefreshToken(unittest.TestCase):
             'The response did not match what was expected: ' + str(token_response)
         )
 
+    @httpretty.activate
+    def test_happy_path_with_resource_adfs(self):
+        tokenRequest = util.setup_expected_refresh_token_request_response(200, self.wire_response, self.response['authority'], self.response['resource'], cp['clientSecret'])
+
+        context = adal.AuthenticationContext(cp['authorityTenant'])
+        def side_effect (tokenfunc):
+            return self.response['decodedResponse']
+
+        context._acquire_token = mock.MagicMock(side_effect=side_effect)
+
+        token_response = context.acquire_token(cp['refreshToken'], cp['clientId'], cp['clientSecret'], cp['resource'])
+        self.assertTrue(
+            util.is_match_token_response(self.response['decodedResponse'], token_response),
+            'The response did not match what was expected: ' + str(token_response)
+        )
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
@rayluo, I will add you to a mail thread with more details
For context, Azure Stack environment uses ADFS 2016. When use MRRT (`multi resource refresh token`) to get an access token for other resources, server doesn't include `resource` in the response payload because it doesn't return a new refresh token. Note, AAD always returns a new refresh token. The consequence is pretty severe, as `resource` is part of the token cache key, and not updating it will corrupt the whole cache.
The change is pretty safe. If you are fine with the option, I will go ahead and add a few test coverage. 