### PR TITLE
Return xml as is

### DIFF
--- a/adal/wstrust_response.py
+++ b/adal/wstrust_response.py
@@ -63,9 +63,18 @@ def findall_content(xml_string, tag):
     >>> findall_content("<ns0:foo> what <bar> ever </bar> content </ns0:foo>", "foo")
     [" what <bar> ever </bar> content "]
 
+    Usually we would use XML parser to extract the data by xpath.
+    However the ElementTree in Python will implicitly normalize the output
+    by "hoisting" the inner inline namespaces into the outmost element.
+    The result will be a semantically equivalent XML snippet,
+    but not fully identical to the original one.
+    While this shouldn't become a problem,
+    in practice it could potentially confuse a picky recipient.
+
+    Introducing this helper, based on Regex, which will return raw content as-is.
     """
-    # https://www.w3.org/TR/REC-xml/#NT-NameChar
-    pattern = r"<(?:\w+:)?%(tag)s>(.*)</(?:\w+:)?%(tag)s" % {"tag": tag}
+    # \w+ is good enough for https://www.w3.org/TR/REC-xml/#NT-NameChar
+    pattern = r"<(?:\w+:)?%(tag)s(?:[^>]*)>(.*)</(?:\w+:)?%(tag)s" % {"tag": tag}
     return re.findall(pattern, xml_string, re.DOTALL)
 
 

--- a/adal/wstrust_response.py
+++ b/adal/wstrust_response.py
@@ -63,15 +63,21 @@ def findall_content(xml_string, tag):
     >>> findall_content("<ns0:foo> what <bar> ever </bar> content </ns0:foo>", "foo")
     [" what <bar> ever </bar> content "]
 
+    Motivation:
+
     Usually we would use XML parser to extract the data by xpath.
     However the ElementTree in Python will implicitly normalize the output
     by "hoisting" the inner inline namespaces into the outmost element.
     The result will be a semantically equivalent XML snippet,
     but not fully identical to the original one.
-    While this shouldn't become a problem,
-    in practice it could potentially confuse a picky recipient.
+    While this effect shouldn't become a problem in all other cases,
+    it does not seem to fully comply with Exclusive XML Canonicalization spec
+    (https://www.w3.org/TR/xml-exc-c14n/), and void the SAML token signature.
+    SAML signature algo needs the "XML -> C14N(XML) -> Signed(C14N(Xml))" order.
 
-    Introducing this helper, based on Regex, which will return raw content as-is.
+    The binary extention lxml is probably the canonical way to solve this
+    (https://stackoverflow.com/questions/22959577/python-exclusive-xml-canonicalization-xml-exc-c14n)
+    but here we use this workaround, based on Regex, to return raw content as-is.
     """
     # \w+ is good enough for https://www.w3.org/TR/REC-xml/#NT-NameChar
     pattern = r"<(?:\w+:)?%(tag)s(?:[^>]*)>(.*)</(?:\w+:)?%(tag)s" % {"tag": tag}

--- a/adal/wstrust_response.py
+++ b/adal/wstrust_response.py
@@ -55,6 +55,20 @@ def scrub_rstr_log_message(response_str):
 
     return 'RSTR Response: ' + scrubbed_rstr
 
+def findall_content(xml_string, tag):
+    """
+    Given a tag name without any prefix,
+    this function returns a list of the raw content inside this tag as-is.
+
+    >>> findall_content("<ns0:foo> what <bar> ever </bar> content </ns0:foo>", "foo")
+    [" what <bar> ever </bar> content "]
+
+    """
+    # https://www.w3.org/TR/REC-xml/#NT-NameChar
+    pattern = r"<(?:\w+:)?%(tag)s>(.*)</(?:\w+:)?%(tag)s" % {"tag": tag}
+    return re.findall(pattern, xml_string, re.DOTALL)
+
+
 class WSTrustResponse(object):
 
     def __init__(self, call_context, response, wstrust_version):
@@ -178,6 +192,15 @@ class WSTrustResponse(object):
         if self.token is None:
             raise AdalError("Unable to find any tokens in RSTR.")
 
+    @staticmethod
+    def _parse_token_by_re(raw_response):
+        for rstr in findall_content(raw_response, "RequestSecurityTokenResponse"):
+            token_types = findall_content(rstr, "TokenType")
+            tokens = findall_content(rstr, "RequestedSecurityToken")
+            if token_types and tokens:
+                return tokens[0].encode('us-ascii'), token_types[0]
+
+
     def parse(self):
         if not self._response:
             raise AdalError("Received empty RSTR response body.")
@@ -195,7 +218,12 @@ class WSTrustResponse(object):
                 str_fault_message = self.fault_message or 'NONE'
                 error_template = 'Server returned error in RSTR - ErrorCode: {} : FaultMessage: {}'
                 raise AdalError(error_template.format(str_error_code, str_fault_message))
-            self._parse_token()
+
+            token_found = self._parse_token_by_re(self._response)
+            if token_found:
+                self.token, self.token_type = token_found
+            else:  # fallback to old logic
+                self._parse_token()
         finally:
             self._dom = None
             self._parents = None

--- a/tests/test_wstrust_response.py
+++ b/tests/test_wstrust_response.py
@@ -36,6 +36,7 @@ except ImportError:
 
 from adal.constants import XmlNamespaces, Errors, WSTrustVersion
 from adal.wstrust_response import WSTrustResponse
+from adal.wstrust_response import findall_content
 
 _namespaces = XmlNamespaces.namespaces
 _call_context = {'log_context' : {'correlation-id':'test-corr-id'}}
@@ -100,6 +101,23 @@ class Test_wstrustresponse(unittest.TestCase):
         with six.assertRaisesRegex(self, Exception, 'Failed to parse RSTR in to DOM'):
             wstrustResponse = WSTrustResponse(_call_context, '<This is not parseable as an RSTR', WSTrustVersion.WSTRUST13)
             wstrustResponse.parse()
+
+    def test_findall_content(self):
+        content = """
+ what <bar> ever </bar> content
+in multiple lines
+"""
+        sample = "<ns0:foo>" + content + "</ns0:foo>"
+        self.assertEqual([content], findall_content(sample, "foo"))
+        self.assertEqual([], findall_content(sample, "nonexist"))
+
+    def test_findall_content_for_real(self):
+        with open(os.path.join(os.getcwd(), 'tests', 'wstrust', 'RSTR.xml')) as f:
+            rstr = f.read()
+        wstrustResponse = WSTrustResponse(_call_context, rstr, WSTrustVersion.WSTRUST13)
+        wstrustResponse.parse()
+        self.assertIn("<X509Data>", rstr)
+        self.assertIn(b"<X509Data>", wstrustResponse.token)  # It is in bytes
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We received ~yet another~ two customer support cases, about unable to authenticate on a federated ADFS environment. And this time we found the clue (thanks @yugangw-msft !), came up with a fix, deployed and tested the patch on that customer's environment. We are now preparing a formal PR for the fix.

You can test this PR by `pip install git+https://github.com/AzureAD/azure-activedirectory-library-for-python.git@return-xml-as-is`

This PR will fix #80 