### PR TITLE
ADAL Python 1.0.0 (was Release Candidate 1.0.0rc1)

### DIFF
--- a/adal/__init__.py
+++ b/adal/__init__.py
@@ -27,7 +27,7 @@
 
 # pylint: disable=wrong-import-position
 
-__version__ = '0.7.0'
+__version__ = '1.0.0'
 
 import logging
 

--- a/adal/authentication_context.py
+++ b/adal/authentication_context.py
@@ -47,7 +47,7 @@ class AuthenticationContext(object):
 
     def __init__(
             self, authority, validate_authority=None, cache=None,
-            api_version='1.0', timeout=None, enable_pii=False, verify_ssl=None, proxies=None):
+            api_version=None, timeout=None, enable_pii=False, verify_ssl=None, proxies=None):
         '''Creates a new AuthenticationContext object.
 
         By default the authority will be checked against a list of known Azure
@@ -68,9 +68,9 @@ class AuthenticationContext(object):
             AuthenticationContexts.
         :param api_version: (optional) Specifies API version using on the wire.
             Historically it has a hardcoded default value as "1.0".
-            Developers are now encouraged to set it as None explicitly,
+            Developers have been encouraged to set it as None explicitly,
             which means the underlying API version will be automatically chosen.
-            In next major release, this default value will be changed to None.
+            Starting from ADAL Python 1.0, this default value becomes None.
         :param timeout: (optional) requests timeout. How long to wait for the server to send
             data before giving up, as a float, or a `(connect timeout,
             read timeout) <timeouts>` tuple.

--- a/sample/certificate_credentials_sample.py
+++ b/sample/certificate_credentials_sample.py
@@ -57,7 +57,7 @@ RESOURCE = sample_parameters.get('resource', GRAPH_RESOURCE)
 turn_on_logging()
 
 ### Main logic begins
-context = adal.AuthenticationContext(authority_url, api_version=None)
+context = adal.AuthenticationContext(authority_url)
 key = get_private_key(sample_parameters['privateKeyFile'])
 
 token = context.acquire_token_with_client_certificate(

--- a/sample/client_credentials_sample.py
+++ b/sample/client_credentials_sample.py
@@ -50,7 +50,7 @@ RESOURCE = sample_parameters.get('resource', GRAPH_RESOURCE)
 ### Main logic begins
 context = adal.AuthenticationContext(
     authority_url, validate_authority=sample_parameters['tenant'] != 'adfs',
-    api_version=None)
+    )
 
 token = context.acquire_token_with_client_credentials(
     RESOURCE,

--- a/sample/device_code_sample.py
+++ b/sample/device_code_sample.py
@@ -51,7 +51,7 @@ RESOURCE = sample_parameters.get('resource', GRAPH_RESOURCE)
 #turn_on_logging()
 
 ### Main logic begins
-context = adal.AuthenticationContext(authority_url, api_version=None)
+context = adal.AuthenticationContext(authority_url)
 code = context.acquire_user_code(RESOURCE, clientid)
 print(code['message'])
 token = context.acquire_token_with_device_code(RESOURCE, code, clientid)

--- a/sample/refresh_token_sample.py
+++ b/sample/refresh_token_sample.py
@@ -51,7 +51,7 @@ RESOURCE = sample_parameters.get('resource', GRAPH_RESOURCE)
 ### Main logic begins
 context = adal.AuthenticationContext(
     authority_url, validate_authority=sample_parameters['tenant'] != 'adfs',
-    api_version=None)
+    )
 
 token = context.acquire_token_with_username_password(
     RESOURCE,

--- a/sample/website_sample.py
+++ b/sample/website_sample.py
@@ -88,7 +88,7 @@ class OAuth2RequestHandler(httpserver.SimpleHTTPRequestHandler):
                 token_response = self._acquire_token()
                 message = 'response: ' + json.dumps(token_response)
                 #Later, if the access token is expired it can be refreshed.
-                auth_context = AuthenticationContext(authority_url, api_version=None)
+                auth_context = AuthenticationContext(authority_url)
                 token_response = auth_context.acquire_token_with_refresh_token(
                     token_response['refreshToken'],
                     sample_parameters['clientId'],
@@ -109,7 +109,7 @@ class OAuth2RequestHandler(httpserver.SimpleHTTPRequestHandler):
         if state != cookie['auth_state'].value:
             raise ValueError('state does not match')
         ### Main logic begins
-        auth_context = AuthenticationContext(authority_url, api_version=None)
+        auth_context = AuthenticationContext(authority_url)
         return auth_context.acquire_token_with_authorization_code(
             code,
             REDIRECT_URI,

--- a/tests/test_api_version.py
+++ b/tests/test_api_version.py
@@ -45,7 +45,8 @@ class TestAuthenticationContextApiVersionBehavior(unittest.TestCase):
             warnings.simplefilter("always")
             context = adal.AuthenticationContext(
                 "https://login.windows.net/tenant")
-            self.assertEqual(context._call_context['api_version'], '1.0')
+            self.assertEqual(context._call_context['api_version'], None)
+            self.assertEqual(len(caught_warnings), 0)
             if len(caught_warnings) == 1:
                 # It should be len(caught_warnings)==1, but somehow it works on
                 # all my local test environment but not on Travis-CI.

--- a/tests/util.py
+++ b/tests/util.py
@@ -374,7 +374,7 @@ def val_exists(val):
 def match_standard_request_headers(mock_request):
     matches = []
     matches.append(mock_request.headers.get('x-client-SKU', None) == 'Python')
-    matches.append(mock_request.headers.get('x-client-Ver', "").startswith('0.'))
+    assert mock_request.headers.get('x-client-Ver') is not None
     matches.append(mock_request.headers.get('x-client-OS', None) != None)
     matches.append(mock_request.headers.get('x-client-CPU', None) != None)
     request_id = correlation_id_regex.match(mock_request.headers.get('client-request-id'))


### PR DESCRIPTION
We are planning for a 1.0.0 ~~rc1~~ release. The following content will become release note:

* It will include [a breaking change which we have planned for more than 1 year now](https://github.com/AzureAD/azure-activedirectory-library-for-python/blob/0.5.1/adal/authentication_context.py#L68-L72).
  The default value of `api_version` parameter in the `AuthenticationContext` constructor will be changed from "1.0" to None. The [previous default value "1.0" was a middleground between backward compatibility and new behavior](https://github.com/AzureAD/azure-activedirectory-library-for-python/pull/57), but it was not very noticeable and people occasionally [forgot to opt-in for the new behavior](https://github.com/AzureAD/azure-activedirectory-library-for-python/pull/102).
  Now we will enable the new behavior by default. Please test this new behavior, and if you encounter issues, please let us know. And you can also explicitly set it to "1.0" to maintain the old behavior, if needed.


To test this release candidate, you can install it by:

    pip install git+https://github.com/AzureAD/azure-activedirectory-library-for-python.git@release-1.0.0

~~Note to self: Do NOT merge this PR yet. We will keep it for a week or two, so that people can test it. Upon merging, we will also need to: (1) rebase to latest dev; (2) change merge base to master.~~ Done.
