### PR TITLE
Add verify and proxies to context

### DIFF
--- a/adal/authentication_context.py
+++ b/adal/authentication_context.py
@@ -77,8 +77,9 @@ class AuthenticationContext(object):
             there will be no Personally Identifiable Information (PII) written in log.
         :param verify_ssl: (optional) requests verify. Either a boolean, in which case it 
             controls whether we verify the server's TLS certificate, or a string, in which 
-            case it must be a path to a CA bundle to use. This value overrides env 
-            variable ADAL_PYTHON_SSL_NO_VERIFY.
+            case it must be a path to a CA bundle to use. If this value is not provided, and 
+            ADAL_PYTHON_SSL_NO_VERIFY env varaible is set, behavior is equivalent to 
+            verify_ssl=False.
         :param proxies: (optional) requests proxies. Dictionary mapping protocol to the URL 
             of the proxy. See http://docs.python-requests.org/en/master/user/advanced/#proxies
             for details.
@@ -86,7 +87,7 @@ class AuthenticationContext(object):
         self.authority = Authority(authority, validate_authority is None or validate_authority)
         self._oauth2client = None
         self.correlation_id = None
-        env_verify = False if 'ADAL_PYTHON_SSL_NO_VERIFY' in os.environ else None
+        env_verify = 'ADAL_PYTHON_SSL_NO_VERIFY' not in os.environ
         verify = verify_ssl if verify_ssl is not None else env_verify
         if api_version is not None:
             warnings.warn(

--- a/adal/authentication_context.py
+++ b/adal/authentication_context.py
@@ -47,7 +47,7 @@ class AuthenticationContext(object):
 
     def __init__(
             self, authority, validate_authority=None, cache=None,
-            api_version='1.0', timeout=None, enable_pii=False):
+            api_version='1.0', timeout=None, enable_pii=False, verify_ssl=None, proxies=None):
         '''Creates a new AuthenticationContext object.
 
         By default the authority will be checked against a list of known Azure
@@ -75,11 +75,17 @@ class AuthenticationContext(object):
             read timeout) <timeouts>` tuple.
         :param enable_pii: (optional) Unless this is set to True,
             there will be no Personally Identifiable Information (PII) written in log.
+        :param verify_ssl: (optional) requests verify. Either a boolean, in which case it 
+            controls whether we verify the server's TLS certificate, or a string, in which 
+            case it must be a path to a CA bundle to use. This value is ignored if env 
+            variable ADAL_PYTHON_SSL_NO_VERIFY is used.
+        :param proxies: (optional) requests proxies. Dictionary mapping protocol to the URL 
+            of the proxy.
         '''
         self.authority = Authority(authority, validate_authority is None or validate_authority)
         self._oauth2client = None
         self.correlation_id = None
-        env_value = os.environ.get('ADAL_PYTHON_SSL_NO_VERIFY')
+        env_value = os.environ.get('ADAL_PYTHON_SSL_NO_VERIFY', verify_ssl)
         if api_version is not None:
             warnings.warn(
                 """The default behavior of including api-version=1.0 on the wire
@@ -95,6 +101,7 @@ class AuthenticationContext(object):
             'options': GLOBAL_ADAL_OPTIONS,
             'api_version': api_version,
             'verify_ssl': None if env_value is None else not env_value, # mainly for tracing through proxy
+            'proxies':proxies,
             'timeout':timeout,
             "enable_pii": enable_pii,
             }

--- a/adal/authentication_context.py
+++ b/adal/authentication_context.py
@@ -77,15 +77,17 @@ class AuthenticationContext(object):
             there will be no Personally Identifiable Information (PII) written in log.
         :param verify_ssl: (optional) requests verify. Either a boolean, in which case it 
             controls whether we verify the server's TLS certificate, or a string, in which 
-            case it must be a path to a CA bundle to use. This value is ignored if env 
-            variable ADAL_PYTHON_SSL_NO_VERIFY is used.
+            case it must be a path to a CA bundle to use. This value overrides env 
+            variable ADAL_PYTHON_SSL_NO_VERIFY.
         :param proxies: (optional) requests proxies. Dictionary mapping protocol to the URL 
-            of the proxy.
+            of the proxy. See http://docs.python-requests.org/en/master/user/advanced/#proxies
+            for details.
         '''
         self.authority = Authority(authority, validate_authority is None or validate_authority)
         self._oauth2client = None
         self.correlation_id = None
-        env_value = os.environ.get('ADAL_PYTHON_SSL_NO_VERIFY', verify_ssl)
+        env_verify = False if 'ADAL_PYTHON_SSL_NO_VERIFY' in os.environ else None
+        verify = verify_ssl if verify_ssl is not None else env_verify
         if api_version is not None:
             warnings.warn(
                 """The default behavior of including api-version=1.0 on the wire
@@ -100,7 +102,7 @@ class AuthenticationContext(object):
         self._call_context = {
             'options': GLOBAL_ADAL_OPTIONS,
             'api_version': api_version,
-            'verify_ssl': None if env_value is None else not env_value, # mainly for tracing through proxy
+            'verify_ssl': verify,
             'proxies':proxies,
             'timeout':timeout,
             "enable_pii": enable_pii,

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -115,7 +115,8 @@ class Authority(object):
 
         try:
             resp = requests.get(discovery_endpoint.geturl(), headers=get_options['headers'],
-                                verify=self._call_context.get('verify_ssl', None))
+                                verify=self._call_context.get('verify_ssl', None),
+                                proxies=self._call_context.get('proxies', None))
             util.log_return_correlation_id(self._log, operation, resp)
         except Exception:
             self._log.exception("%(operation)s request failed",

--- a/adal/mex.py
+++ b/adal/mex.py
@@ -79,7 +79,8 @@ class Mex(object):
         try:
             operation = "Mex Get"
             resp = requests.get(self._url, headers=options['headers'],
-                                verify=self._call_context.get('verify_ssl', None))
+                                verify=self._call_context.get('verify_ssl', None),
+                                proxies=self._call_context.get('proxies', None))
             util.log_return_correlation_id(self._log, operation, resp)
         except Exception:
             self._log.exception(

--- a/adal/oauth2_client.py
+++ b/adal/oauth2_client.py
@@ -264,6 +264,7 @@ class OAuth2Client(object):
                                  data=url_encoded_token_request, 
                                  headers=post_options['headers'],
                                  verify=self._call_context.get('verify_ssl', None),
+                                 proxies=self._call_context.get('proxies', None),
                                  timeout=self._call_context.get('timeout', None))
 
             util.log_return_correlation_id(self._log, operation, resp)
@@ -298,6 +299,7 @@ class OAuth2Client(object):
                                  data=url_encoded_code_request, 
                                  headers=post_options['headers'],
                                  verify=self._call_context.get('verify_ssl', None),
+                                 proxies=self._call_context.get('proxies', None),
                                  timeout=self._call_context.get('timeout', None))
             util.log_return_correlation_id(self._log, operation, resp)
         except Exception:
@@ -339,6 +341,7 @@ class OAuth2Client(object):
             resp = requests.post(
                 token_url.geturl(), 
                 data=url_encoded_code_request, headers=post_options['headers'],
+                proxies=self._call_context.get('proxies', None),
                 verify=self._call_context.get('verify_ssl', None))
             if resp.status_code == 429:
                 resp.raise_for_status()  # Will raise requests.exceptions.HTTPError

--- a/adal/user_realm.py
+++ b/adal/user_realm.py
@@ -143,6 +143,7 @@ class UserRealm(object):
 
         operation = 'User Realm Discovery'
         resp = requests.get(user_realm_url.geturl(), headers=options['headers'],
+                            proxies=self._call_context.get('proxies', None),
                             verify=self._call_context.get('verify_ssl', None))
         util.log_return_correlation_id(self._log, operation, resp)
 

--- a/adal/wstrust_request.py
+++ b/adal/wstrust_request.py
@@ -147,6 +147,7 @@ class WSTrustRequest(object):
         resp = requests.post(self._wstrust_endpoint_url, headers=options['headers'], data=rst,
                              allow_redirects=True,
                              verify=self._call_context.get('verify_ssl', None),
+                             proxies=self._call_context.get('proxies', None),
                              timeout=self._call_context.get('timeout', None))
 
         util.log_return_correlation_id(self._log, operation, resp)


### PR DESCRIPTION
Hi,

I work with @yugangw-msft in the SDK/CLI team. I'm migrating the Autorest internal authentication system to use 100% of ADAL, so all SDK/CLI queries pass through it.
Part of my migration, I realized that my current implementation support verify/proxies as context parameters, where ADAL does not. This PR is just passing through `requests` verify/proxies. No breaking changes, just let the options pass to `requests`. Documentation strings are taken from `requests` directly.

Reference:
http://docs.python-requests.org/en/master/user/advanced/#proxies

Let me know if you have questions (internal email or here)
Thank you!

Laurent