### PR TITLE
Relax authority check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Microsoft Azure Active Directory Authentication Library (ADAL) for Python
 =====================================
 
+[![Build Status](https://travis-ci.org/AzureAD/azure-activedirectory-library-for-python.svg?branch=dev)](https://travis-ci.org/AzureAD/azure-activedirectory-library-for-python)
+[![Documentation Status](https://readthedocs.org/projects/adal-python/badge/?version=latest)](https://adal-python.readthedocs.io/en/latest/?badge=latest)
+
 |[Getting Started](https://github.com/AzureAD/azure-activedirectory-library-for-python/wiki)| [Docs](https://aka.ms/aaddev)| [Samples](https://github.com/azure-samples?query=active-directory)| [Support](README.md#community-help-and-support)
 | --- | --- | --- | --- |
 

--- a/README.md
+++ b/README.md
@@ -1,72 +1,38 @@
 # Microsoft Azure Active Directory Authentication Library (ADAL) for Python
+=====================================
 
-The ADAL for python library makes it easy for python applications to authenticate to AAD in order to access AAD protected web resources.
+|[Getting Started](https://github.com/AzureAD/azure-activedirectory-library-for-python/wiki)| [Docs](https://aka.ms/aaddev)| [Samples](https://github.com/azure-samples?query=active-directory)| [Support](README.md#community-help-and-support)
+| --- | --- | --- | --- |
 
-## Usage
 
-### Install
+The ADAL for Python library enables python applications to authenticate with Azure AD and get tokens to access Azure AD protected web resources.
 
-To support 'service principal' with certificate, ADAL depends on the 'cryptography' package. For smooth installation, some suggestions:
+You can learn in detail about ADAL Python functionality and usage documented in the [Wiki](https://github.com/AzureAD/azure-activedirectory-library-for-python/wiki).
 
-* For Windows and macOS
+## Versions
+Current version - 0.6.0
 
-  Upgrade to the latest pip (8.1.2 as of June 2016) and just do `pip install adal`.
+Minimum recommended version - 0.6.0
 
-* For Linux
+You can find the changes for each version under [Releases](https://github.com/AzureAD/azure-activedirectory-library-for-python/releases).
 
-  Upgrade to the latest pip (8.1.2 as of June 2016).
+> Note: Changes on 'client_id' and 'resource' arguments after 0.1.0
+>
+>The convenient methods in 0.1.0 have been removed, and now your application should provide parameter values to `client_id` and `resource`.
+>
+>2 Reasons:
+>
+>* Each adal client should have an Application ID representing a valid application registered in a tenant. The old methods borrowed the client-id of [azure-cli](https://github.com/Azure/azure-xplat-cli), which is never right. It is simple to register your application and get a client id. You can follow [this article](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications).
+>
+>* The old method defaults the `resource` argument to 'https://management.core.windows.net/', now you can just supply this value explictly. Please note, there are lots of different azure resources you can acquire tokens through adal though, for example, the samples in the repository acquire for the 'graph' resource. Because it is not an appropriate assumption to be made at the library level, we removed the old defaults.
 
-  You'll need a C compiler, libffi + its development headers, and openssl + its development headers.
-  Refer to [cryptography installation](https://cryptography.io/en/latest/installation/)
-
-* To install from source:
-
-  Upgrade to the latest pip (8.1.2 as of June 2016).
-  To avoid dealing with compilation errors from cryptography, first run `pip install cryptography` to use statically-linked wheels.
-  Next, run `python setup.py install`
-
-  If you still like to build from source, refer to [cryptography installation](https://cryptography.io/en/latest/installation/).
-  For more context, start with this [stackoverflow thread](http://stackoverflow.com/questions/22073516/failed-to-install-python-cryptography-package-with-pip-and-setup-py).
-
-### Acquire Token with Client Credentials
-
-In order to use this token acquisition method, you need to configure a service principal. Please follow [this walkthrough](https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/).
-
-Find the `Main logic` part in the [sample](sample/client_credentials_sample.py#L46-L55).
-
-### Acquire Token with client certificate
-A service principal is also required.
-Find the `Main logic` part in the [sample](sample/certificate_credentials_sample.py#L55-L64).
-
-### Acquire Token with Refresh Token
-Find the `Main logic` part in the [sample](sample/refresh_token_sample.py#L47-L69).
-
-### Acquire Token with device code
-Find the `Main logic` part in the [sample](sample/device_code_sample.py#L49-L54).
-
-### Acquire Token with authorization code
-Find the `Main logic` part in the [sample](sample/website_sample.py#L107-L115) for a complete bare bones web site that makes use of the code below.
-
-## Logging
-
-#### Personal Identifiable Information (PII) & Organizational Identifiable Information (OII)
-
-Starting from ADAL Python 0.5.1, by default, ADAL logging does not capture or log any PII or OII.  The library allows app developers to turn this on by configuring the `enable_pii` flag on the AuthenticationContext. By turning on PII or OII, the app takes responsibility for safely handling highly-sensitive data and complying with any regulatory requirements.
-
-```python
-//PII or OII logging disabled. Default Logger does not capture any PII or OII.
-auth_context = AuthenticationContext(...)
-
-//PII or OII logging enabled
-auth_context = AuthenticationContext(..., enable_pii=True)
-```
 
 ## Samples and Documentation
-We provide a full suite of [sample applications on GitHub](https://github.com/azure-samples?utf8=%E2%9C%93&q=active-directory&type=&language=) and an [Azure AD developer landing page](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-developers-guide) to help you get started with learning the Azure Identity system. This includes tutorials for native clients and web applications. We also provide full walkthroughs for authentication flows such as OAuth2, OpenID Connect and for calling APIs such as the Graph API.
+We provide a full suite of [sample applications on GitHub](https://github.com/azure-samples?utf8=%E2%9C%93&q=active-directory&type=&language=) to help you get started with learning the Azure Identity system. This includes tutorials for native clients and web applications. We also provide full walkthroughs for authentication flows such as OAuth2, OpenID Connect and for calling APIs such as the Graph API.
 
-It is recommended to read the [Auth Scenarios](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-authentication-scenarios) doc, specifically the [Scenarios section](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-authentication-scenarios#application-types-and-scenarios).  For some topics about registering/integrating an app, checkout [this doc](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications).  And finally, we have a great topic on the Auth protocols you would be using and how they play with Azure AD in [this doc](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-openid-connect-code).
+You can find the relevant samples by scenarios listed in this [document](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-code-samples) as well as [inside this library repo](https://github.com/AzureAD/azure-activedirectory-library-for-python/tree/dev/sample).
 
-While Python-specific samples will be added into the aforementioned documents as an on-going effort, you can always find [most relevant samples just inside this library repo](https://github.com/AzureAD/azure-activedirectory-library-for-python/tree/dev/sample).
+The documents on [Auth Scenarios](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-authentication-scenarios#application-types-and-scenarios) and [Auth protocols](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-openid-connect-code) are recommended reading.
 
 ## Community Help and Support
 
@@ -80,29 +46,8 @@ If you find a security issue with our libraries or services please report it to 
 
 ## Contributing
 
-All code is licensed under the MIT license and we triage actively on GitHub. We enthusiastically welcome contributions and feedback. You can clone the repo and start contributing now.
+All code is licensed under the MIT license and we triage actively on GitHub. We enthusiastically welcome contributions and feedback. Please read the [contributing guide](./contributing.md) before starting.
 
 ## We Value and Adhere to the Microsoft Open Source Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
-## Quick Start
-
-### Installation
-
-``` $ pip install adal ```
-
-### http tracing/proxy
-If you need to bypass self-signed certificates, turn on the environment variable of `ADAL_PYTHON_SSL_NO_VERIFY`
-
-
-## Note
-
-### Changes on 'client_id' and 'resource' arguments after 0.1.0
-The convenient methods in 0.1.0 have been removed, and now your application should provide parameter values to `client_id` and `resource`.
-
-2 Reasons:
-
-* Each adal client should have an Application ID representing a valid application registered in a tenant. The old methods borrowed the client-id of [azure-cli](https://github.com/Azure/azure-xplat-cli), which is never right. It is simple to register your application and get a client id. You can follow [this walkthrough](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications). Do check out if you are new to AAD.
-
-* The old method defaults the `resource` argument to 'https://management.core.windows.net/', now you can just supply this value explictly. Please note, there are lots of different azure resources you can acquire tokens through adal though, for example, the samples in the repository acquire for the 'graph' resource. Because it is not an appropriate assumption to be made at the library level, we removed the old defaults.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Microsoft Azure Active Directory Authentication Library (ADAL) for Python
 =====================================
 
-[![Build Status](https://travis-ci.org/AzureAD/azure-activedirectory-library-for-python.svg?branch=dev)](https://travis-ci.org/AzureAD/azure-activedirectory-library-for-python)
-[![Documentation Status](https://readthedocs.org/projects/adal-python/badge/?version=latest)](https://adal-python.readthedocs.io/en/latest/?badge=latest)
+ `master` branch    | `dev` branch    | Reference Docs
+--------------------|-----------------|---------------
+[![Build Status](https://travis-ci.org/AzureAD/azure-activedirectory-library-for-python.svg?branch=master)](https://travis-ci.org/AzureAD/azure-activedirectory-library-for-python) | [![Build Status](https://travis-ci.org/AzureAD/azure-activedirectory-library-for-python.svg?branch=dev)](https://travis-ci.org/AzureAD/azure-activedirectory-library-for-python) | [![Documentation Status](https://readthedocs.org/projects/adal-python/badge/?version=latest)](https://adal-python.readthedocs.io/en/latest/?badge=latest)
 
 |[Getting Started](https://github.com/AzureAD/azure-activedirectory-library-for-python/wiki)| [Docs](https://aka.ms/aaddev)| [Samples](https://github.com/azure-samples?query=active-directory)| [Support](README.md#community-help-and-support)
 | --- | --- | --- | --- |

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -1,4 +1,4 @@
-﻿#------------------------------------------------------------------------------
+﻿# ------------------------------------------------------------------------------
 #
 # Copyright (c) Microsoft Corporation. 
 # All rights reserved.
@@ -23,19 +23,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 try:
     from urllib.parse import quote, urlparse
 except ImportError:
-    from urllib import quote # pylint: disable=no-name-in-module
-    from urlparse import urlparse # pylint: disable=import-error,ungrouped-imports
+    from urllib import quote  # pylint: disable=no-name-in-module
+    from urlparse import urlparse  # pylint: disable=import-error,ungrouped-imports
 
 import requests
 from .constants import AADConstants
 from .adal_error import AdalError
 from . import log
 from . import util
+
 
 class Authority(object):
 
@@ -70,9 +71,9 @@ class Authority(object):
             raise ValueError("The authority url must not have a query string.")
 
         path_parts = list(filter(None, self._url.path.split('/')))
-        if len(path_parts)>1:
+        if len(path_parts) > 1:
             raise ValueError("The authority url must be of the format https://login.microsoftonline.com/your_tenant")
-        elif len(path_parts)==1:
+        elif len(path_parts) == 1:
             self._url = urlparse(self._url.geturl().rstrip('/'))
 
     def _parse_authority(self):
@@ -97,16 +98,16 @@ class Authority(object):
         return True
 
     def _create_authority_url(self):
-        return "https://{}/{}{}".format(self._url.hostname, 
-                                        self._tenant, 
+        return "https://{}/{}{}".format(self._url.hostname,
+                                        self._tenant,
                                         AADConstants.AUTHORIZE_ENDPOINT_PATH)
 
     def _create_instance_discovery_endpoint_from_template(self, authority_host):
 
         discovery_endpoint = AADConstants.INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE
         discovery_endpoint = discovery_endpoint.replace('{authorize_host}', authority_host)
-        discovery_endpoint = discovery_endpoint.replace('{authorize_endpoint}', 
-                                                        quote(self._create_authority_url(), 
+        discovery_endpoint = discovery_endpoint.replace('{authorize_endpoint}',
+                                                        quote(self._create_authority_url(),
                                                               safe='~()*!.\''))
         return urlparse(discovery_endpoint)
 
@@ -131,7 +132,7 @@ class Authority(object):
         if resp.status_code == 429:
             resp.raise_for_status()  # Will raise requests.exceptions.HTTPError
         if not util.is_http_success(resp.status_code):
-            return_error_string = u"{} request returned http error: {}".format(operation, 
+            return_error_string = u"{} request returned http error: {}".format(operation,
                                                                                resp.status_code)
             error_response = ""
             if resp.text:

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -70,7 +70,8 @@ class Authority(object):
         if self._url.query:
             raise ValueError("The authority url must not have a query string.")
 
-        path_parts = list(filter(None, self._url.path.split('/')))
+        path_parts = [part for part in self._url.path.split('/') if part]
+
         if len(path_parts) > 1:
             raise ValueError("The authority url must be of the format https://login.microsoftonline.com/your_tenant")
         elif len(path_parts) == 1:

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -32,7 +32,6 @@ except ImportError:
     from urlparse import urlparse # pylint: disable=import-error,ungrouped-imports
 
 import requests
-import re
 from .constants import AADConstants
 from .adal_error import AdalError
 from . import log

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -32,7 +32,7 @@ except ImportError:
     from urlparse import urlparse # pylint: disable=import-error,ungrouped-imports
 
 import requests
-
+import re
 from .constants import AADConstants
 from .adal_error import AdalError
 from . import log
@@ -70,8 +70,11 @@ class Authority(object):
         if self._url.query:
             raise ValueError("The authority url must not have a query string.")
 
-        if self._url.path.count('/') > 1:
+        path_parts = list(filter(None, self._url.path.split('/')))
+        if len(path_parts)>1:
             raise ValueError("The authority url must be of the format https://login.microsoftonline.com/your_tenant")
+        elif len(path_parts)==1:
+            self._url = urlparse(self._url.geturl().rstrip('/'))
 
     def _parse_authority(self):
         self._host = self._url.hostname

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -32,6 +32,7 @@ except ImportError:
     from urlparse import urlparse # pylint: disable=import-error,ungrouped-imports
 
 import requests
+
 from .constants import AADConstants
 from .adal_error import AdalError
 from . import log
@@ -97,16 +98,16 @@ class Authority(object):
         return True
 
     def _create_authority_url(self):
-        return "https://{}/{}{}".format(self._url.hostname,
-                                        self._tenant,
+        return "https://{}/{}{}".format(self._url.hostname, 
+                                        self._tenant, 
                                         AADConstants.AUTHORIZE_ENDPOINT_PATH)
 
     def _create_instance_discovery_endpoint_from_template(self, authority_host):
 
         discovery_endpoint = AADConstants.INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE
         discovery_endpoint = discovery_endpoint.replace('{authorize_host}', authority_host)
-        discovery_endpoint = discovery_endpoint.replace('{authorize_endpoint}',
-                                                        quote(self._create_authority_url(),
+        discovery_endpoint = discovery_endpoint.replace('{authorize_endpoint}', 
+                                                        quote(self._create_authority_url(), 
                                                               safe='~()*!.\''))
         return urlparse(discovery_endpoint)
 

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -1,4 +1,4 @@
-﻿# ------------------------------------------------------------------------------
+﻿#------------------------------------------------------------------------------
 #
 # Copyright (c) Microsoft Corporation. 
 # All rights reserved.
@@ -23,20 +23,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-# ------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 
 try:
     from urllib.parse import quote, urlparse
 except ImportError:
-    from urllib import quote  # pylint: disable=no-name-in-module
-    from urlparse import urlparse  # pylint: disable=import-error,ungrouped-imports
+    from urllib import quote # pylint: disable=no-name-in-module
+    from urlparse import urlparse # pylint: disable=import-error,ungrouped-imports
 
 import requests
 from .constants import AADConstants
 from .adal_error import AdalError
 from . import log
 from . import util
-
 
 class Authority(object):
 
@@ -71,7 +70,6 @@ class Authority(object):
             raise ValueError("The authority url must not have a query string.")
 
         path_parts = [part for part in self._url.path.split('/') if part]
-
         if len(path_parts) > 1:
             raise ValueError("The authority url must be of the format https://login.microsoftonline.com/your_tenant")
         elif len(path_parts) == 1:
@@ -133,7 +131,7 @@ class Authority(object):
         if resp.status_code == 429:
             resp.raise_for_status()  # Will raise requests.exceptions.HTTPError
         if not util.is_http_success(resp.status_code):
-            return_error_string = u"{} request returned http error: {}".format(operation,
+            return_error_string = u"{} request returned http error: {}".format(operation, 
                                                                                resp.status_code)
             error_response = ""
             if resp.text:

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -186,6 +186,28 @@ class TestAuthority(unittest.TestCase):
                                                      "https://login.microsoftonline.com/your_tenant"):
             context = AuthenticationContext(self.nonHardCodedAuthority + '/extra/path')
 
+    @httpretty.activate
+    def test_url_extra_slashes(self):
+        util.setup_expected_instance_discovery_request(200,
+                                                       cp['authorityHosts']['global'],
+                                                       {
+                                                           'tenant_discovery_endpoint': 'http://foobar'
+                                                       },
+                                                       self.nonHardCodedAuthorizeEndpoint)
+
+        authority_url = self.nonHardCodedAuthority + '//'
+        authority = Authority(authority_url, True)
+        obj = util.create_empty_adal_object()
+        authority.validate(obj['call_context'])
+        req = httpretty.last_request()
+        util.match_standard_request_headers(req)
+
+    @httpretty.activate
+    def test_url_extra_slashes_change_authority_url(self):
+        authority_url = self.nonHardCodedAuthority + '//'
+        authority = Authority(authority_url, True)
+        self.assertTrue(authority._url.geturl(), self.nonHardCodedAuthority)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -195,7 +195,7 @@ class TestAuthority(unittest.TestCase):
                                                        },
                                                        self.nonHardCodedAuthorizeEndpoint)
 
-        authority_url = self.nonHardCodedAuthority + '/'
+        authority_url = self.nonHardCodedAuthority + '/'  # This should pass for one or more than one slashes
         authority = Authority(authority_url, True)
         obj = util.create_empty_adal_object()
         authority.validate(obj['call_context'])
@@ -204,7 +204,7 @@ class TestAuthority(unittest.TestCase):
 
     @httpretty.activate
     def test_url_extra_slashes_change_authority_url(self):
-        authority_url = self.nonHardCodedAuthority + '/'
+        authority_url = self.nonHardCodedAuthority + '/'  # This should pass for one or more than one slashes
         authority = Authority(authority_url, True)
         self.assertTrue(authority._url.geturl(), self.nonHardCodedAuthority)
 

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -195,7 +195,7 @@ class TestAuthority(unittest.TestCase):
                                                        },
                                                        self.nonHardCodedAuthorizeEndpoint)
 
-        authority_url = self.nonHardCodedAuthority + '//'
+        authority_url = self.nonHardCodedAuthority + '/'
         authority = Authority(authority_url, True)
         obj = util.create_empty_adal_object()
         authority.validate(obj['call_context'])
@@ -204,7 +204,7 @@ class TestAuthority(unittest.TestCase):
 
     @httpretty.activate
     def test_url_extra_slashes_change_authority_url(self):
-        authority_url = self.nonHardCodedAuthority + '//'
+        authority_url = self.nonHardCodedAuthority + '/'
         authority = Authority(authority_url, True)
         self.assertTrue(authority._url.geturl(), self.nonHardCodedAuthority)
 


### PR DESCRIPTION
This relaxes the authority url check to allow customers to add slashes after the tenant. 
It then normalizes the url by removing these extra slashes. 
Solves #156 