### PR TITLE
fix an incorrect cache operation on authorization code flow

### DIFF
--- a/adal/token_request.py
+++ b/adal/token_request.py
@@ -319,12 +319,6 @@ class TokenRequest(object):
     def get_token_with_authorization_code(self, authorization_code, client_secret, code_verifier):
 
         self._log.info("Getting token with auth code.")
-        try:
-            token = self._find_token_from_cache()
-            if token:
-                return token
-        except AdalError:
-            self._log.exception('Attempt to look for token in cache resulted in Error')
         oauth_parameters = self._create_oauth_parameters(OAUTH2_GRANT_TYPE.AUTHORIZATION_CODE)
         oauth_parameters[OAUTH2_PARAMETERS.CODE] = authorization_code
         if client_secret is not None:
@@ -332,7 +326,7 @@ class TokenRequest(object):
         if code_verifier is not None:
             oauth_parameters[OAUTH2_PARAMETERS.CODE_VERIFIER] = code_verifier
         token = self._oauth_get_token(oauth_parameters)
-        self._cache_driver.add(token)
+        self._add_token_into_cache(token)
         return token
 
     def _get_token_with_refresh_token(self, refresh_token, resource, client_secret):


### PR DESCRIPTION
//CC: @rayluo 
My Change #138 was not right by searching the cache before sending out the request because at that time we don't know the userID, so the entry returned from cache might be issued to other users.
So I am reverting it and replace with the right fix, which is one line change like we did on [device code](https://github.com/AzureAD/azure-activedirectory-library-for-python/blob/dev/adal/token_request.py#L404)
The unit test introduce by #138 is still kept as it verifies the right scenario, that the token from the wire response will be saved in cache.