### PR TITLE
Upgrade crytography to 2.3 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyJWT==1.0.0
 #need 2.x for Python3 support
 python-dateutil==2.1.0
 #1.1.0 is the first that can be installed on windows
-cryptography==1.1.0
+cryptography==2.3.0
 #for testing
 httpretty==0.8.14
 pylint==1.5.4


### PR DESCRIPTION
We update our dev and test environment to use cryptography 2.3, the [current latest version](https://cryptography.io/en/latest/changelog/). The Travis-CI job is [using such latest version now](https://travis-ci.org/AzureAD/azure-activedirectory-library-for-python/jobs/415693509#L432), and all existing test cases still pass.

PS: The real dependency in production has long been set up to [use latest version](https://github.com/AzureAD/azure-activedirectory-library-for-python/blob/1.0.2/setup.py#L79) all the time.