### PR TITLE
Fix an incorrect variable name

### DIFF
--- a/adal/mex.py
+++ b/adal/mex.py
@@ -144,7 +144,7 @@ class Mex(object):
             policy_id = self._check_policy(policy_node)
             if policy_id:
                 id_ref = '#' + policy_id
-                policies[id_ref] = {id:id_ref}
+                policies[id_ref] = {policy_id:id_ref}
 
         return policies if policies else None
 


### PR DESCRIPTION
This change was [the missing piece from another change happened 3 years ago](https://github.com/AzureAD/azure-activedirectory-library-for-python/pull/7/files#diff-65d1b2afb1c288ac2145a56635e7b6d2R128).

The interesting thing is, this incorrect variable name exists for 3 years and it does NOT affect the actual functionality. This is because that part of variable and its information are not used in current business logic at all. Such a fact is a strong sign that the current code structure has room for improvement. We are rewriting the entire mex.py in a new project.

Since we spot this issue here, we still send out this patch for this code base.
