### PR TITLE
 Change info to debug for message

### DIFF
--- a/adal/token_request.py
+++ b/adal/token_request.py
@@ -342,7 +342,7 @@ class TokenRequest(object):
         return self._get_token_with_refresh_token(refresh_token, None, client_secret)
 
     def get_token_from_cache_with_refresh(self, user_id):
-        self._log.info("Getting token from cache with refresh if necessary.")
+        self._log.debug("Getting token from cache with refresh if necessary.")
         self._user_id = user_id
         return self._find_token_from_cache()
 


### PR DESCRIPTION
Get rid of really annoying info message I see in my terminal when running my code with debug level set to Info
I see this message appear every half a second, if it's that frequent it shouldn't be an info level message.