### PR TITLE
Reword the ValueError text when tenant is not right

### DIFF
--- a/adal/authority.py
+++ b/adal/authority.py
@@ -78,7 +78,13 @@ class Authority(object):
 
         path_parts = [part for part in self._url.path.split('/') if part]
         if (len(path_parts) > 1) and (not self._whitelisted()): #if dsts host, path_parts will be 2
-            raise ValueError("The authority url must be of the format https://login.microsoftonline.com/your_tenant")
+            raise ValueError(
+                "The path of authority_url, also known as the tenant, "
+                "should be a domain name like mycompany.onmicrosoft.com "
+                "or a GUID style of tenant id. "
+                "Your tenant input \"%s\" and your entire authority_url \"%s\" "
+                "do not look like that."
+                % ('/'.join(path_parts), self._url.geturl()))
         elif len(path_parts) == 1:
             self._url = urlparse(self._url.geturl().rstrip('/'))
 

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -79,11 +79,10 @@ class Authority(object):
         path_parts = [part for part in self._url.path.split('/') if part]
         if (len(path_parts) > 1) and (not self._whitelisted()): #if dsts host, path_parts will be 2
             raise ValueError(
-                "The path of authority_url, also known as the tenant, "
-                "should be a domain name like mycompany.onmicrosoft.com "
-                "or a GUID style of tenant id. "
-                "Your tenant input \"%s\" and your entire authority_url \"%s\" "
-                "do not look like that."
+                "The path of authority_url (also known as tenant) is invalid, "
+                "it should either be a domain name (e.g. mycompany.onmicrosoft.com) "
+                "or a tenant GUID id. "
+                'Your tenant input was "%s" and your entire authority_url was "%s".'
                 % ('/'.join(path_parts), self._url.geturl()))
         elif len(path_parts) == 1:
             self._url = urlparse(self._url.geturl().rstrip('/'))

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -188,8 +188,7 @@ class TestAuthority(unittest.TestCase):
 
     @httpretty.activate
     def test_url_extra_path_elements(self):
-        with six.assertRaisesRegex(self, ValueError, "The authority url must be of the format "+
-                                                     "https://login.microsoftonline.com/your_tenant"):
+        with six.assertRaisesRegex(self, ValueError, "tenant"):  # Some tenant specific error message
             context = AuthenticationContext(self.nonHardCodedAuthority + '/extra/path')
 
     @httpretty.activate


### PR DESCRIPTION
This is an attempt to fix #201 . It would generate a record-breaking long description like this:

> ~ValueError: The path of authority_url, also known as the tenant, should be a domain name like mycompany.onmicrosoft.com or a GUID style of tenant id. Your tenant input "https:/example.com/foo/bar" and your entire authority_url "https://login.microsoftonline.com/https://example.com/foo/bar" do not look like that.~

> ValueError: The path of authority_url (also known as tenant) is invalid, it should either be a domain name (e.g. mycompany.onmicrosoft.com) or a tenant GUID id. Your tenant input was "https:/example.com/foo/bar" and your entire authority_url was "https://login.microsoftonline.com/https://example.com/foo/bar"

If you want to have a hands-on test, you can probably grab this patch branch by:

    pip install git+https://github.com/AzureAD/azure-activedirectory-library-for-python.git@reword-tenant-exception-description

and then rerun your (Azure CLI) test command.