### PR TITLE
Enable dynamic whitelisting of dSTS endpoints to support new buildouts

### DIFF
--- a/adal/authority.py
+++ b/adal/authority.py
@@ -1,4 +1,4 @@
-﻿#------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 #
 # Copyright (c) Microsoft Corporation. 
 # All rights reserved.
@@ -96,8 +96,8 @@ class Authority(object):
         self._log.debug("Performing static instance discovery")
         
         if self._whitelisted(): # testing if self._url.hostname is a dsts whitelisted domain
-        		self._log.debug("Authority validated via static instance discovery")
-        		return True
+            self._log.debug("Authority validated via static instance discovery")
+            return True
         try:
             AADConstants.WELL_KNOWN_AUTHORITY_HOSTS.index(self._url.hostname)
         except ValueError:

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -63,8 +63,8 @@ class Authority(object):
         return self._url.geturl()
         
     def _whitelisted(self): # testing if self._url.hostname is a dsts whitelisted domain
-        for domain in AADConstants.WHITELISTED_DOMAINS :
-            if self._url.hostname.endswith(domain) :
+        for domain in AADConstants.WHITELISTED_DOMAINS:
+            if self._url.hostname.endswith(domain):
                 return True
         return False
 
@@ -77,7 +77,7 @@ class Authority(object):
             raise ValueError("The authority url must not have a query string.")
 
         path_parts = [part for part in self._url.path.split('/') if part]
-        if (len(path_parts) > 1) and (not self._whitelisted()) : #if dsts host, path_parts will be 2
+        if (len(path_parts) > 1) and (not self._whitelisted()): #if dsts host, path_parts will be 2
             raise ValueError("The authority url must be of the format https://login.microsoftonline.com/your_tenant")
         elif len(path_parts) == 1:
             self._url = urlparse(self._url.geturl().rstrip('/'))

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -117,7 +117,7 @@ class Authority(object):
 
     def _perform_dynamic_instance_discovery(self):
         discovery_endpoint = self._create_instance_discovery_endpoint_from_template(
-            self.authority_url)
+            AADConstants.WORLD_WIDE_AUTHORITY)
         get_options = util.create_request_options(self)
         operation = "Instance Discovery"
         self._log.debug("Attempting instance discover at: %(discovery_endpoint)s",

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -43,7 +43,6 @@ class Authority(object):
     def __init__(self, authority_url, validate_authority=True):
 
         self._log = None
-        self._whitelisted_domains = []
         self._call_context = None
         self._url = urlparse(authority_url)
 
@@ -64,16 +63,9 @@ class Authority(object):
         return self._url.geturl()
 
     def _whitelisted(self): # testing if self._url.hostname is a dsts whitelisted domain
-        for domain in self._whitelisted_domains:
-            if self._url.hostname.endswith(domain):
-                return True
         # Add dSTS domains to whitelist based on based on domain
         # https://microsoft.sharepoint.com/teams/AzureSecurityCompliance/Security/SitePages/dSTS%20Fundamentals.aspx
-        if self._url.hostname.find(".dsts.") > -1:
-            index = self._url.hostname.find(".dsts.")
-            self._whitelisted_domains.append(self._url.hostname[index+1:])
-            return True
-        return False
+        return ".dsts." in self._url.hostname
 
     def _validate_authority_url(self):
 

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -43,6 +43,7 @@ class Authority(object):
     def __init__(self, authority_url, validate_authority=True):
 
         self._log = None
+        self._whitelisted_domains = []
         self._call_context = None
         self._url = urlparse(authority_url)
 
@@ -63,15 +64,15 @@ class Authority(object):
         return self._url.geturl()
         
     def _whitelisted(self): # testing if self._url.hostname is a dsts whitelisted domain
-        for domain in AADConstants.WHITELISTED_DOMAINS:
+        for domain in self._whitelisted_domains:
             if self._url.hostname.endswith(domain):
                 return True
-        return False
-
-    def _whitelisted(self): # testing if self._url.hostname is a dsts whitelisted domain
-        for domain in AADConstants.WHITELISTED_DOMAINS:
-            if self._url.hostname.endswith(domain):
-                return True
+        # Add dSTS domains to whitelist based on based on domain
+        # https://microsoft.sharepoint.com/teams/AzureSecurityCompliance/Security/SitePages/dSTS%20Fundamentals.aspx
+        if self._url.hostname.find(".dsts.") > -1:
+            index = self._url.hostname.find(".dsts.")
+            self._whitelisted_domains.append(self._url.hostname[index+1:])
+            return True
         return False
 
     def _validate_authority_url(self):

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -88,6 +88,7 @@ class Authority(object):
     def _perform_static_instance_discovery(self):
 
         self._log.debug("Performing static instance discovery")
+        
         for domains in AADConstants.WHITELISTED_DOMAINS :
             if self._url.hostname.endswith(domains) :
                 self._log.debug("Authority validated via static instance discovery")
@@ -121,6 +122,7 @@ class Authority(object):
         operation = "Instance Discovery"
         self._log.debug("Attempting instance discover at: %(discovery_endpoint)s",
                         {"discovery_endpoint": discovery_endpoint.geturl()})
+                        	
         try:
             resp = requests.get(discovery_endpoint.geturl(), headers=get_options['headers'],
                                 verify=self._call_context.get('verify_ssl', None),

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -62,7 +62,7 @@ class Authority(object):
     @property
     def url(self):
         return self._url.geturl()
-        
+
     def _whitelisted(self): # testing if self._url.hostname is a dsts whitelisted domain
         for domain in self._whitelisted_domains:
             if self._url.hostname.endswith(domain):
@@ -106,7 +106,7 @@ class Authority(object):
     def _perform_static_instance_discovery(self):
 
         self._log.debug("Performing static instance discovery")
-        
+
         if self._whitelisted(): # testing if self._url.hostname is a dsts whitelisted domain
             self._log.debug("Authority validated via static instance discovery")
             return True

--- a/adal/authority.py
+++ b/adal/authority.py
@@ -90,7 +90,7 @@ class Authority(object):
             self._tenant = path_parts[1]
         except IndexError:
             raise ValueError("Could not determine tenant.")
- 
+
     def _perform_static_instance_discovery(self):
 
         self._log.debug("Performing static instance discovery")
@@ -127,7 +127,7 @@ class Authority(object):
         operation = "Instance Discovery"
         self._log.debug("Attempting instance discover at: %(discovery_endpoint)s",
                         {"discovery_endpoint": discovery_endpoint.geturl()})
-                        	
+
         try:
             resp = requests.get(discovery_endpoint.geturl(), headers=get_options['headers'],
                                 verify=self._call_context.get('verify_ssl', None),

--- a/adal/constants.py
+++ b/adal/constants.py
@@ -1,4 +1,4 @@
-﻿#------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 #
 # Copyright (c) Microsoft Corporation. 
 # All rights reserved.
@@ -216,7 +216,7 @@ class AADConstants(object):
         'login.microsoftonline.de',
         ]
     WHITELISTED_DOMAINS = [
-    		#add dsts domains to whitelist
+        #add dsts domains to whitelist
         'dsts.core.windows.net',
         'dsts.core.chinacloudapi.cn',  
         'dsts.core.cloudapi.de', 

--- a/adal/constants.py
+++ b/adal/constants.py
@@ -215,6 +215,13 @@ class AADConstants(object):
         'login.microsoftonline.us',
         'login.microsoftonline.de',
         ]
+    WHITELISTED_DOMAINS = [
+        'dsts.core.windows.net',
+        'dsts.core.chinacloudapi.cn',  
+        'dsts.core.cloudapi.de', 
+        'dsts.core.usgovcloudapi.net',  
+        'dsts.core.azure-test.net',
+        ]
     INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE = 'https://{authorize_host}/common/discovery/instance?authorization_endpoint={authorize_endpoint}&api-version=1.0' # pylint: disable=invalid-name
     AUTHORIZE_ENDPOINT_PATH = '/oauth2/authorize'
     TOKEN_ENDPOINT_PATH = '/oauth2/token'

--- a/adal/constants.py
+++ b/adal/constants.py
@@ -216,6 +216,7 @@ class AADConstants(object):
         'login.microsoftonline.de',
         ]
     WHITELISTED_DOMAINS = [
+    		#add dsts domains to whitelist
         'dsts.core.windows.net',
         'dsts.core.chinacloudapi.cn',  
         'dsts.core.cloudapi.de', 

--- a/adal/constants.py
+++ b/adal/constants.py
@@ -217,15 +217,6 @@ class AADConstants(object):
         'login.microsoftonline.us',
         'login.microsoftonline.de',
         ]
-    WHITELISTED_DOMAINS = [
-        # Define dSTS domains whitelist based on its Supported Environments & National Clouds list here
-        # https://microsoft.sharepoint.com/teams/AzureSecurityCompliance/Security/SitePages/dSTS%20Fundamentals.aspx
-        'dsts.core.windows.net',
-        'dsts.core.chinacloudapi.cn',  
-        'dsts.core.cloudapi.de', 
-        'dsts.core.usgovcloudapi.net',  
-        'dsts.core.azure-test.net',
-        ]
     INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE = 'https://{authorize_host}/common/discovery/instance?authorization_endpoint={authorize_endpoint}&api-version=1.0' # pylint: disable=invalid-name
     AUTHORIZE_ENDPOINT_PATH = '/oauth2/authorize'
     TOKEN_ENDPOINT_PATH = '/oauth2/token'

--- a/adal/constants.py
+++ b/adal/constants.py
@@ -216,7 +216,8 @@ class AADConstants(object):
         'login.microsoftonline.de',
         ]
     WHITELISTED_DOMAINS = [
-        #add dsts domains to whitelist
+        # Define dSTS domains whitelist based on its Supported Environments & National Clouds list here
+        # https://microsoft.sharepoint.com/teams/AzureSecurityCompliance/Security/SitePages/dSTS%20Fundamentals.aspx
         'dsts.core.windows.net',
         'dsts.core.chinacloudapi.cn',  
         'dsts.core.cloudapi.de', 

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -128,7 +128,7 @@ class TestAuthority(unittest.TestCase):
         self.performStaticInstanceDiscovery('login-us.microsoftonline.com')
         self.performStaticInstanceDiscovery('test-dsts.dsts.core.windows.net')
         self.performStaticInstanceDiscovery('test-dsts.dsts.core.chinacloudapi.cn')
-        self.performStaticInstanceDiscovery('test-dsts.dsts.core.cloudapi.de'
+        self.performStaticInstanceDiscovery('test-dsts.dsts.core.cloudapi.de')
         self.performStaticInstanceDiscovery('test-dsts.dsts.core.usgovcloudapi.net')
         self.performStaticInstanceDiscovery('test-dsts.core.azure-test.net')
 

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -60,7 +60,7 @@ class TestAuthority(unittest.TestCase):
     # discovery.
     nonHardCodedAuthority = 'https://login.doesntexist.com/' + cp['tenant']
     nonHardCodedAuthorizeEndpoint = nonHardCodedAuthority + '/oauth2/authorize'
-    dstsTestEndpoint = 'https://test-dsts.core.azure-test.net/dstsv2/common'
+    dstsTestEndpoint = 'https://test-dsts.dsts.core.azure-test.net/dstsv2/common'
 
 
     def setUp(self):

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -197,7 +197,7 @@ class TestAuthority(unittest.TestCase):
             context = AuthenticationContext(self.dstsTestEndpoint)
         except:
             self.fail("AuthenticationContext() rased an exception on dstsTestEndpoint")
-				
+
     @httpretty.activate
     def test_url_extra_slashes(self):
         util.setup_expected_instance_discovery_request(200,

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -130,7 +130,7 @@ class TestAuthority(unittest.TestCase):
         self.performStaticInstanceDiscovery('test-dsts.dsts.core.chinacloudapi.cn')
         self.performStaticInstanceDiscovery('test-dsts.dsts.core.cloudapi.de')
         self.performStaticInstanceDiscovery('test-dsts.dsts.core.usgovcloudapi.net')
-        self.performStaticInstanceDiscovery('test-dsts.core.azure-test.net')
+        self.performStaticInstanceDiscovery('test-dsts.dsts.core.azure-test.net')
 
 
     @httpretty.activate

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -194,7 +194,7 @@ class TestAuthority(unittest.TestCase):
 
     @httpretty.activate
     def test_dsts_authority(self):
-	    context = AuthenticationContext(self.dstsTestEndpoint)
+            context = AuthenticationContext(self.dstsTestEndpoint)
 				
     @httpretty.activate
     def test_url_extra_slashes(self):

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -60,6 +60,7 @@ class TestAuthority(unittest.TestCase):
     # discovery.
     nonHardCodedAuthority = 'https://login.doesntexist.com/' + cp['tenant']
     nonHardCodedAuthorizeEndpoint = nonHardCodedAuthority + '/oauth2/authorize'
+    dstsTestEndpoint = 'https://test-dsts.core.azure-test.net/dstsv2/common'
 
 
     def setUp(self):
@@ -125,6 +126,11 @@ class TestAuthority(unittest.TestCase):
         self.performStaticInstanceDiscovery('login.windows.net')
         self.performStaticInstanceDiscovery('login.chinacloudapi.cn')
         self.performStaticInstanceDiscovery('login-us.microsoftonline.com')
+        self.performStaticInstanceDiscovery('test-dsts.dsts.core.windows.net')
+        self.performStaticInstanceDiscovery('test-dsts.dsts.core.chinacloudapi.cn')
+        self.performStaticInstanceDiscovery('test-dsts.dsts.core.cloudapi.de'
+        self.performStaticInstanceDiscovery('test-dsts.dsts.core.usgovcloudapi.net')
+        self.performStaticInstanceDiscovery('test-dsts.core.azure-test.net')
 
 
     @httpretty.activate
@@ -186,6 +192,10 @@ class TestAuthority(unittest.TestCase):
                                                      "https://login.microsoftonline.com/your_tenant"):
             context = AuthenticationContext(self.nonHardCodedAuthority + '/extra/path')
 
+		@httpretty.activate
+    def test_dsts_authority(self):
+				context = AuthenticationContext(self.dstsTestEndpoint)
+				
     @httpretty.activate
     def test_url_extra_slashes(self):
         util.setup_expected_instance_discovery_request(200,

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -1,4 +1,4 @@
-﻿#------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 #
 # Copyright (c) Microsoft Corporation. 
 # All rights reserved.
@@ -192,9 +192,9 @@ class TestAuthority(unittest.TestCase):
                                                      "https://login.microsoftonline.com/your_tenant"):
             context = AuthenticationContext(self.nonHardCodedAuthority + '/extra/path')
 
-		@httpretty.activate
+    @httpretty.activate
     def test_dsts_authority(self):
-				context = AuthenticationContext(self.dstsTestEndpoint)
+	    context = AuthenticationContext(self.dstsTestEndpoint)
 				
     @httpretty.activate
     def test_url_extra_slashes(self):

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -194,7 +194,10 @@ class TestAuthority(unittest.TestCase):
 
     @httpretty.activate
     def test_dsts_authority(self):
+        try:
             context = AuthenticationContext(self.dstsTestEndpoint)
+        except:
+            self.fail("AuthenticationContext() rased an exception on dstsTestEndpoint")
 				
     @httpretty.activate
     def test_url_extra_slashes(self):


### PR DESCRIPTION
Enable dynamic whitelisting of dSTS endpoints to support new buildouts of national cloud environments.

UPDATED info quoted from PR conversation:

The new authority.py implementation for dSTS is to support (future) new cloud environments in which we will not be allowed to explicitly whitelist endpoints in public GitHub repos due to customer restrictions on releasing DNS names. Since I have removed dSTS whitelisting constants, these test cases should be sufficient to cover all current and future dSTS endpoints that fit the .dsts. DNS address pattern.