### PR TITLE
Advertise MSAL Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+---
+
+This library, ADAL for Python, will no longer receive new feature improvement. Its successor,
+[MSAL for Python](https://github.com/AzureAD/microsoft-authentication-library-for-python),
+are now generally available.
+
+* If you are starting a new project, you can get started with the
+  [MSAL Python docs](https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki)
+  for details about the scenarios, usage, and relevant concepts.
+* If your application is using the previous ADAL Python library, you can follow this
+  [migration guide](https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-python-adal-msal)
+  to update to MSAL Python.
+* Existing applications relying on ADAL Python will continue to work.
+
+---
+
 # Microsoft Azure Active Directory Authentication Library (ADAL) for Python
 
  `master` branch    | `dev` branch    | Reference Docs

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,14 +8,14 @@
 
 .. note::
    This library, ADAL for Python, will no longer receive new feature improvement. Its successor,
-   [MSAL for Python](https://github.com/AzureAD/microsoft-authentication-library-for-python),
+   `MSAL for Python<https://github.com/AzureAD/microsoft-authentication-library-for-python>`_,
    are now generally available.
 
    * If you are starting a new project, you can get started with the
-     [MSAL Python docs](https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki)
+     `MSAL Python docs<https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki>`_
      for details about the scenarios, usage, and relevant concepts.
    * If your application is using the previous ADAL Python library, you can follow this
-     [migration guide](https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-python-adal-msal)
+     `migration guide<https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-python-adal-msal>`_
      to update to MSAL Python.
    * Existing applications relying on ADAL Python will continue to work.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,20 @@
 .. This file is also inspired by
    https://pythonhosted.org/an_example_pypi_project/sphinx.html#full-code-example
 
+.. note::
+   This library, ADAL for Python, will no longer receive new feature improvement. Its successor,
+   [MSAL for Python](https://github.com/AzureAD/microsoft-authentication-library-for-python),
+   are now generally available.
+
+   * If you are starting a new project, you can get started with the
+     [MSAL Python docs](https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki)
+     for details about the scenarios, usage, and relevant concepts.
+   * If your application is using the previous ADAL Python library, you can follow this
+     [migration guide](https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-python-adal-msal)
+     to update to MSAL Python.
+   * Existing applications relying on ADAL Python will continue to work.
+
+
 Welcome to ADAL Python's documentation!
 =======================================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,14 +8,14 @@
 
 .. note::
    This library, ADAL for Python, will no longer receive new feature improvement. Its successor,
-   `MSAL for Python<https://github.com/AzureAD/microsoft-authentication-library-for-python>`_,
+   `MSAL for Python <https://github.com/AzureAD/microsoft-authentication-library-for-python>`_,
    are now generally available.
 
    * If you are starting a new project, you can get started with the
-     `MSAL Python docs<https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki>`_
+     `MSAL Python docs <https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki>`_
      for details about the scenarios, usage, and relevant concepts.
    * If your application is using the previous ADAL Python library, you can follow this
-     `migration guide<https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-python-adal-msal>`_
+     `migration guide <https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-python-adal-msal>`_
      to update to MSAL Python.
    * Existing applications relying on ADAL Python will continue to work.
 


### PR DESCRIPTION
Currently some customers would still land on ADAL Python materials, such as, #218.
This change in README would help us guide customers to MSAL Python.

@navyasric @abhidnya13 please proofread. CC: @henrik-me 

Once we finalize on the wording, we can also add same changes into ADAL Python's API reference docs, and its wiki home page.