### PR TITLE
Removal of login.windows.net / login-us

### DIFF
--- a/adal/authentication_parameters.py
+++ b/adal/authentication_parameters.py
@@ -53,7 +53,7 @@ class AuthenticationParameters(object):
 # The 401 challenge is a standard defined in RFC6750, which is based in part on RFC2617.
 # The challenge has the following form.
 # WWW-Authenticate : Bearer
-#     authorization_uri="https://login.windows.net/mytenant.com/oauth2/authorize",
+#     authorization_uri="https://login.microsoftonline.com/mytenant.com/oauth2/authorize",
 #     Resource_id="00000002-0000-0000-c000-000000000000"
 
 # This regex is used to validate the structure of the challenge header.

--- a/adal/constants.py
+++ b/adal/constants.py
@@ -208,12 +208,10 @@ class HttpError(object):
 
 class AADConstants(object):
 
-    WORLD_WIDE_AUTHORITY = 'login.windows.net'
+    WORLD_WIDE_AUTHORITY = 'login.microsoftonline.com'
     WELL_KNOWN_AUTHORITY_HOSTS = [
-        'login.windows.net',
         'login.microsoftonline.com',
         'login.chinacloudapi.cn',
-        'login-us.microsoftonline.com',
         'login.microsoftonline.us',
         'login.microsoftonline.de',
         ]

--- a/adal/constants.py
+++ b/adal/constants.py
@@ -210,6 +210,7 @@ class AADConstants(object):
 
     WORLD_WIDE_AUTHORITY = 'login.microsoftonline.com'
     WELL_KNOWN_AUTHORITY_HOSTS = [
+        'login.windows.net',
         'login.microsoftonline.com',
         'login.chinacloudapi.cn',
         'login.microsoftonline.us',

--- a/adal/log.py
+++ b/adal/log.py
@@ -151,7 +151,7 @@ def scrub_pii(arg_dict, padding="..."):
         "redirect_uri",
 
         # Unintuitively, the following can contain PII
-        "user_realm_url",  # e.g. https://login.windows.net/common/UserRealm/{username}
+        "user_realm_url",  # e.g. https://login.microsoftonline.com/common/UserRealm/{username}
         ])
     return {k: padding if k.lower() in pii else arg_dict[k] for k in arg_dict}
 

--- a/sample/website_sample.py
+++ b/sample/website_sample.py
@@ -49,7 +49,7 @@ else:
     raise ValueError('Please provide parameter file with account information.')
 
 PORT = 8088
-TEMPLATE_AUTHZ_URL = ('https://login.windows.net/{}/oauth2/authorize?'+
+TEMPLATE_AUTHZ_URL = ('https://login.microsoftonline.com/{}/oauth2/authorize?'+
                       'response_type=code&client_id={}&redirect_uri={}&'+
                       'state={}&resource={}')
 GRAPH_RESOURCE = '00000002-0000-0000-c000-000000000000'

--- a/tests/config_sample.py
+++ b/tests/config_sample.py
@@ -42,7 +42,7 @@ ACQUIRE_TOKEN_WITH_USERNAME_PASSWORD = {
     "password" : "None",
     "tenant" : "XXXXXXXX.onmicrosoft.com",
 
-    "authorityHostUrl" : "https://login.windows.net",
+    "authorityHostUrl" : "https://login.microsoftonline.com",
 }
 
 ACQUIRE_TOKEN_WITH_CLIENT_CREDENTIALS = {

--- a/tests/test_api_version.py
+++ b/tests/test_api_version.py
@@ -44,7 +44,7 @@ class TestAuthenticationContextApiVersionBehavior(unittest.TestCase):
         with warnings.catch_warnings(record=True) as caught_warnings:
             warnings.simplefilter("always")
             context = adal.AuthenticationContext(
-                "https://login.windows.net/tenant")
+                "https://login.microsoftonline.com/tenant")
             self.assertEqual(context._call_context['api_version'], None)
             self.assertEqual(len(caught_warnings), 0)
             if len(caught_warnings) == 1:
@@ -57,7 +57,7 @@ class TestAuthenticationContextApiVersionBehavior(unittest.TestCase):
         with warnings.catch_warnings(record=True) as caught_warnings:
             warnings.simplefilter("always")
             context = adal.AuthenticationContext(
-                "https://login.windows.net/tenant", api_version=None)
+                "https://login.microsoftonline.com/tenant", api_version=None)
             self.assertEqual(context._call_context['api_version'], None)
             self.assertEqual(len(caught_warnings), 0)
 

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -123,9 +123,8 @@ class TestAuthority(unittest.TestCase):
     def test_success_static_instance_discovery(self):
 
         self.performStaticInstanceDiscovery('login.microsoftonline.com')
-        self.performStaticInstanceDiscovery('login.windows.net')
         self.performStaticInstanceDiscovery('login.chinacloudapi.cn')
-        self.performStaticInstanceDiscovery('login-us.microsoftonline.com')
+        self.performStaticInstanceDiscovery('login.microsoftonline.us')
         self.performStaticInstanceDiscovery('test-dsts.dsts.core.windows.net')
         self.performStaticInstanceDiscovery('test-dsts.dsts.core.chinacloudapi.cn')
         self.performStaticInstanceDiscovery('test-dsts.dsts.core.cloudapi.de')

--- a/tests/test_self_signed_jwt.py
+++ b/tests/test_self_signed_jwt.py
@@ -56,7 +56,7 @@ class TestSelfSignedJwt(unittest.TestCase):
     expectedJwtWithPublicCert = cp['expectedJwtWithPublicCert']
 
     unexpectedJwt = 'unexpectedJwt'
-    testAuthority = Authority('https://login.windows.net/naturalcauses.com', False)
+    testAuthority = Authority('https://login.microsoftonline.com/naturalcauses.com', False)
     testClientId = 'd6835713-b745-48d1-bb62-7a8248477d35'
     testCert = cp['cert']
     testPublicCert=cp['publicCert']

--- a/tests/test_user_realm.py
+++ b/tests/test_user_realm.py
@@ -52,7 +52,7 @@ from tests.util import parameters as cp
 class TestUserRealm(unittest.TestCase):
 
     def setUp(self):
-        self.authority = 'https://login.windows.net'
+        self.authority = 'https://login.microsoftonline.com'
         self.user = 'test@federatedtenant-com'
 
         user_realm_path = cp['userRealmPathTemplate'].replace('<user>', quote(self.user, safe='~()*!.\''))

--- a/tests/util.py
+++ b/tests/util.py
@@ -122,13 +122,13 @@ parameters = {
     'clientId': 'clien&&???tId',
     'clientSecret': 'clientSecret*&^(?&',
     'resource': '00000002-0000-0000-c000-000000000000',
-    'evoEndpoint': 'https://login.windows.net/',
+    'evoEndpoint': 'https://login.microsoftonline.com/',
     'username': 'rrandall@rrandallaad1.onmicrosoft.com',
     'password': '<password>',
     'authorityHosts': {
-        'global': 'login.windows.net',
+        'global': 'login.microsoftonline.com',
         'china': 'login.chinacloudapi.cn',
-        'gov': 'login-us.microsoftonline.com'
+        'gov': 'login.microsoftonline.us'
     }
 }
 


### PR DESCRIPTION
Login.windows.net needs to be replaced by login.microsoftonline.com.  Also removing legacy US Gov endpoint that has been retired (login-us.microsoftonline.com)

---

Notes (by Ray): This PR will fix #224.