### PR TITLE
Update metadata for next release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,5 @@
 universal=1
 
 [metadata]
-description-file = README.md
+long_description = file: README.md
+long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,6 @@ __version__ = re.search(
     io.open('adal/__init__.py', encoding='utf_8_sig').read()
     ).group(1)
 
-try:
-    long_description = open('README.md').read()
-except OSError:
-    long_description = "README.md is not accessible on TRAVIS CI's Python 3.5"
-
 # To build:
 # python setup.py sdist
 # python setup.py bdist_wheel
@@ -67,10 +62,8 @@ setup(
     author='Microsoft Corporation',
     author_email='nugetaad@microsoft.com',
     url='https://github.com/AzureAD/azure-activedirectory-library-for-python',
-    long_description=long_description,
-    long_description_content_type="text/markdown",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
+        'Development Status :: 6 - Mature',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,11 @@ __version__ = re.search(
     io.open('adal/__init__.py', encoding='utf_8_sig').read()
     ).group(1)
 
+try:
+    long_description = open('README.md').read()
+except OSError:
+    long_description = "README.md is not accessible on TRAVIS CI's Python 3.5"
+
 # To build:
 # python setup.py sdist
 # python setup.py bdist_wheel
@@ -54,13 +59,16 @@ setup(
     version=__version__,
     description=('The ADAL for Python library makes it easy for python ' +
                  'application to authenticate to Azure Active Directory ' +
-                 '(AAD) in order to access AAD protected web resources.'),
+                 '(AAD) in order to access AAD protected web resources. ' +
+                 '(It is now SUPERSEDED by MSAL Python.)'),
     license='MIT',
     author='Microsoft Corporation',
     author_email='nugetaad@microsoft.com',
     url='https://github.com/AzureAD/azure-activedirectory-library-for-python',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -57,10 +57,12 @@ except OSError:
 setup(
     name='adal',
     version=__version__,
-    description=('The ADAL for Python library makes it easy for python ' +
+    description=('Note: This library is already replaced by MSAL Python, ' +
+                 'available here: https://pypi.org/project/msal/ .' +
+                 'ADAL Python remains available here as a legacy. ' +
+                 'The ADAL for Python library makes it easy for python ' +
                  'application to authenticate to Azure Active Directory ' +
-                 '(AAD) in order to access AAD protected web resources. ' +
-                 '(It is now SUPERSEDED by MSAL Python.)'),
+                 '(AAD) in order to access AAD protected web resources.'),
     license='MIT',
     author='Microsoft Corporation',
     author_email='nugetaad@microsoft.com',


### PR DESCRIPTION
The substantial changes in this PR is only this: `It is now SUPERSEDED by MSAL Python.` The [longer description in current README](https://github.com/AzureAD/azure-activedirectory-library-for-python/blame/1.2.3/README.md#L3-L12) will be automatically picked up in next release.

This will fix https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/192

---

It is confirmed, [PyPI does not allowed a project's metadata to be updated without a new release](https://github.com/pypa/warehouse/issues/2170). Precisely speaking:

* PyPI records metadata for each release (thus they are immutable - which is reasonable);
* PyPI does not store metadata for a project, which is a surprise;
* And then PyPI misleadingly displays the latest release's metadata for a project, which is semantically incorrect. (For example, today, we can see [MSAL EX Python 0.1.0](https://pypi.org/project/msal-extensions/0.1.0/) and [MSAL EX Python 0.2.2](https://pypi.org/project/msal-extensions/0.2.2/) contain different metadata, and [MSAL EX Python "homepage"](https://pypi.org/project/msal-extensions/) shows the latest version's metadata.)

This means we will have to prepare for a new release to change metadata for a package that would otherwise remain unchanged for years to come.
