### PR TITLE
Federated flow fix

### DIFF
--- a/adal/token_request.py
+++ b/adal/token_request.py
@@ -223,7 +223,6 @@ class TokenRequest(object):
 
             wstrust_version = TokenRequest._parse_wstrust_version_from_federation_active_authurl(
                 self._user_realm.federation_active_auth_url)
-
             self._log.debug(
                 'wstrust endpoint version is: %(wstrust_version)s',
                 {"wstrust_version": wstrust_version})

--- a/adal/token_request.py
+++ b/adal/token_request.py
@@ -213,6 +213,7 @@ class TokenRequest(object):
     def _get_token_username_password_federated(self, username, password):
         self._log.debug("Acquiring token with username password for federated user")
 
+        cloud_audience_urn = self._user_realm.cloud_audience_urn
         if not self._user_realm.federation_metadata_url:
             self._log.warn("Unable to retrieve federationMetadataUrl from AAD. "
                            "Attempting fallback to AAD supplied endpoint.")
@@ -222,7 +223,7 @@ class TokenRequest(object):
 
             wstrust_version = TokenRequest._parse_wstrust_version_from_federation_active_authurl(
                 self._user_realm.federation_active_auth_url)
-            cloud_audience_urn = self._user_realm.cloud_audience_urn
+
             self._log.debug(
                 'wstrust endpoint version is: %(wstrust_version)s',
                 {"wstrust_version": wstrust_version})
@@ -232,7 +233,6 @@ class TokenRequest(object):
                 wstrust_version, cloud_audience_urn, username, password)
         else:
             mex_endpoint = self._user_realm.federation_metadata_url
-            cloud_audience_urn = self._user_realm.cloud_audience_urn
             self._log.debug(
                 "Attempting mex at: %(mex_endpoint)s",
                 {"mex_endpoint": mex_endpoint})

--- a/adal/user_realm.py
+++ b/adal/user_realm.py
@@ -132,7 +132,7 @@ class UserRealm(object):
             self.federation_protocol = protocol
             self.federation_metadata_url = response['federation_metadata_url']
             self.federation_active_auth_url = response['federation_active_auth_url']
-            self.cloud_audience_urn = response['cloud_audience_urn']
+            self.cloud_audience_urn = response.get('cloud_audience_urn', "urn:federation:MicrosoftOnline")
 
         self._log_parsed_response()
 

--- a/adal/user_realm.py
+++ b/adal/user_realm.py
@@ -57,6 +57,7 @@ class UserRealm(object):
         self.account_type = None
         self.federation_metadata_url = None
         self.federation_active_auth_url = None
+        self.cloud_audience_urn = None
         self._user_principle = user_principle
         self._authority_url = authority_url
 
@@ -131,6 +132,7 @@ class UserRealm(object):
             self.federation_protocol = protocol
             self.federation_metadata_url = response['federation_metadata_url']
             self.federation_active_auth_url = response['federation_active_auth_url']
+            self.cloud_audience_urn = response['cloud_audience_urn']
 
         self._log_parsed_response()
 

--- a/adal/wstrust_request.py
+++ b/adal/wstrust_request.py
@@ -41,10 +41,10 @@ _PASSWORD_PLACEHOLDER = '{PasswordPlaceHolder}'
 
 class WSTrustRequest(object):
 
-    def __init__(self, call_context, watrust_endpoint_url, applies_to, wstrust_endpoint_version):
+    def __init__(self, call_context, wstrust_endpoint_url, applies_to, wstrust_endpoint_version):
         self._log = log.Logger('WSTrustRequest', call_context['log_context'])
         self._call_context = call_context
-        self._wstrust_endpoint_url = watrust_endpoint_url
+        self._wstrust_endpoint_url = wstrust_endpoint_url
         self._applies_to = applies_to
         self._wstrust_endpoint_version = wstrust_endpoint_version
         


### PR DESCRIPTION
While testing for migration of Fairfax,  username-password federated was failing, this PR includes the fix.

The problem was ADAL was hardcoding Cloud_audience_urn which is now fetched from the mex response.
