### PR TITLE
Release 1.2.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/a-template-reminding-adal-s-status.md
+++ b/.github/ISSUE_TEMPLATE/a-template-reminding-adal-s-status.md
@@ -1,0 +1,19 @@
+---
+name: A template reminding ADAL's status
+about: So that people are guided to use MSAL Python instead.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+This library, ADAL for Python, will no longer receive new feature improvements. Instead, use the new library [MSAL for Python](https://github.com/AzureAD/microsoft-authentication-library-for-python).
+
+*    If you are starting a new project, you can get started with the MSAL Python docs for details about the scenarios, usage, and relevant concepts.
+*    If your application is using the previous ADAL Python library, you can follow this migration guide to update to MSAL Python.
+*    Existing applications relying on ADAL Python will continue to work.
+
+---
+
+If you encounter a bug, please reproduce it using our off-the-shelf
+[samples](https://github.com/AzureAD/azure-activedirectory-library-for-python/tree/1.2.4/sample), so that we can follow your steps.

--- a/adal/__init__.py
+++ b/adal/__init__.py
@@ -27,7 +27,7 @@
 
 # pylint: disable=wrong-import-position
 
-__version__ = '1.2.4'
+__version__ = '1.2.5'
 
 import logging
 

--- a/adal/token_request.py
+++ b/adal/token_request.py
@@ -190,9 +190,9 @@ class TokenRequest(object):
 
         return self._oauth_get_token(oauth_parameters)
 
-    def _perform_wstrust_exchange(self, wstrust_endpoint, wstrust_endpoint_version, username, password):
+    def _perform_wstrust_exchange(self, wstrust_endpoint, wstrust_endpoint_version, cloud_audience_urn, username, password):
 
-        wstrust = self._create_wstrust_request(wstrust_endpoint, "urn:federation:MicrosoftOnline",
+        wstrust = self._create_wstrust_request(wstrust_endpoint, cloud_audience_urn,
                                                wstrust_endpoint_version)
         result = wstrust.acquire_token(username, password)
 
@@ -204,15 +204,16 @@ class TokenRequest(object):
 
         return result
 
-    def _perform_username_password_for_access_token_exchange(self, wstrust_endpoint, wstrust_endpoint_version,
+    def _perform_username_password_for_access_token_exchange(self, wstrust_endpoint, wstrust_endpoint_version, cloud_audience_urn,
                                                              username, password):
-        wstrust_response = self._perform_wstrust_exchange(wstrust_endpoint, wstrust_endpoint_version,
+        wstrust_response = self._perform_wstrust_exchange(wstrust_endpoint, wstrust_endpoint_version, cloud_audience_urn,
                                                           username, password)
         return self._perform_wstrust_assertion_oauth_exchange(wstrust_response)
 
     def _get_token_username_password_federated(self, username, password):
         self._log.debug("Acquiring token with username password for federated user")
 
+        cloud_audience_urn = self._user_realm.cloud_audience_urn
         if not self._user_realm.federation_metadata_url:
             self._log.warn("Unable to retrieve federationMetadataUrl from AAD. "
                            "Attempting fallback to AAD supplied endpoint.")
@@ -228,7 +229,7 @@ class TokenRequest(object):
 
             return self._perform_username_password_for_access_token_exchange(
                 self._user_realm.federation_active_auth_url,
-                wstrust_version, username, password)
+                wstrust_version, cloud_audience_urn, username, password)
         else:
             mex_endpoint = self._user_realm.federation_metadata_url
             self._log.debug(
@@ -253,6 +254,7 @@ class TokenRequest(object):
                     raise AdalError('AAD did not return a WSTrust endpoint. Unable to proceed.')
 
             return self._perform_username_password_for_access_token_exchange(wstrust_endpoint, wstrust_version,
+                                                                             cloud_audience_urn,
                                                                              username, password)
     @staticmethod
     def _parse_wstrust_version_from_federation_active_authurl(federation_active_authurl):

--- a/adal/user_realm.py
+++ b/adal/user_realm.py
@@ -57,6 +57,7 @@ class UserRealm(object):
         self.account_type = None
         self.federation_metadata_url = None
         self.federation_active_auth_url = None
+        self.cloud_audience_urn = None
         self._user_principle = user_principle
         self._authority_url = authority_url
 
@@ -131,6 +132,7 @@ class UserRealm(object):
             self.federation_protocol = protocol
             self.federation_metadata_url = response['federation_metadata_url']
             self.federation_active_auth_url = response['federation_active_auth_url']
+            self.cloud_audience_urn = response.get('cloud_audience_urn', "urn:federation:MicrosoftOnline")
 
         self._log_parsed_response()
 

--- a/adal/wstrust_request.py
+++ b/adal/wstrust_request.py
@@ -41,10 +41,10 @@ _PASSWORD_PLACEHOLDER = '{PasswordPlaceHolder}'
 
 class WSTrustRequest(object):
 
-    def __init__(self, call_context, watrust_endpoint_url, applies_to, wstrust_endpoint_version):
+    def __init__(self, call_context, wstrust_endpoint_url, applies_to, wstrust_endpoint_version):
         self._log = log.Logger('WSTrustRequest', call_context['log_context'])
         self._call_context = call_context
-        self._wstrust_endpoint_url = watrust_endpoint_url
+        self._wstrust_endpoint_url = wstrust_endpoint_url
         self._applies_to = applies_to
         self._wstrust_endpoint_version = wstrust_endpoint_version
         


### PR DESCRIPTION
* Bugfix to address error "InvalidScope : FaultMessage: ID3082: The request scope is not valid or is unsupported." when using username-password flow with federated user account while your tenant is migrating to a different cloud. (#240)